### PR TITLE
Features/artifacts

### DIFF
--- a/brooklyn-tosca-transformer/src/main/java/org/apache/brooklyn/tosca/a4c/brooklyn/ToscaNodeToEntityConverter.java
+++ b/brooklyn-tosca-transformer/src/main/java/org/apache/brooklyn/tosca/a4c/brooklyn/ToscaNodeToEntityConverter.java
@@ -171,6 +171,7 @@ public class ToscaNodeToEntityConverter {
         spec.configure(SoftwareProcess.PROVISIONING_PROPERTIES, prov.getAllConfig());
 
         configurePropertiesForSpec(spec, nodeTemplate);
+        configureArtifactsForSpec(spec, nodeTemplate);
 
         configureRuntimeEnvironment(spec);
 
@@ -264,6 +265,18 @@ public class ToscaNodeToEntityConverter {
         ConfigBag bag = ConfigBag.newInstance(getTemplatePropertyObjects(nodeTemplate));
         // now set configuration for all the items in the bag
         configureConfigKeysSpec(spec, bag);
+    }
+
+    private void configureArtifactsForSpec(EntitySpec<?> spec, NodeTemplate nodeTemplate) {
+        Map<String, Object> a= MutableMap.of();
+        Map<String, DeploymentArtifact> artifacts = nodeTemplate.getArtifacts();
+        if(artifacts!=null) {
+            for(String artifactId: artifacts.keySet() ){
+                a.put(artifactId, artifacts.get(artifactId).getArtifactRef());
+            }
+            ConfigBag bag = ConfigBag.newInstance(a);
+            configureConfigKeysSpec(spec, bag);
+        }
     }
 
     private void configureConfigKeysSpec(EntitySpec spec, ConfigBag bag){

--- a/brooklyn-tosca-transformer/src/test/java/org/apache/brooklyn/tosca/a4c/brooklyn/ToscaPlanToSpecTransformerTest.java
+++ b/brooklyn-tosca-transformer/src/test/java/org/apache/brooklyn/tosca/a4c/brooklyn/ToscaPlanToSpecTransformerTest.java
@@ -286,4 +286,25 @@ public class ToscaPlanToSpecTransformerTest extends Alien4CloudToscaTest {
             }
         }
     }
+
+    @Test
+    public void testDeploymentArtifacts() {
+        String templateUrl = getClasspathUrlForResource("templates/deployment-artifact.tosca.yaml");
+
+        EntitySpec<? extends Application> app = transformer.createApplicationSpec(
+                new ResourceUtils(mgmt).getResourceAsString(templateUrl));
+
+        assertNotNull(app);
+        assertEquals(app.getChildren().size(), 1);
+
+        EntitySpec<TomcatServer> tomcatServer =
+                (EntitySpec<TomcatServer>) ToscaPlanToSpecTransformer
+                        .findChildEntitySpecByPlanId(app, "tomcat_server");
+        assertEquals(tomcatServer.getConfig().get(TomcatServer.ROOT_WAR),
+                "http://search.maven.org/remotecontent?filepath=io/brooklyn/example/" +
+                        "brooklyn-example-hello-world-sql-webapp/0.6.0/" +
+                        "brooklyn-example-hello-world-sql-webapp-0.6.0.war");
+    }
+
+
 }

--- a/brooklyn-tosca-transformer/src/test/resources/templates/deployment-artifact.tosca.yaml
+++ b/brooklyn-tosca-transformer/src/test/resources/templates/deployment-artifact.tosca.yaml
@@ -1,0 +1,52 @@
+tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
+
+imports:
+  - tosca-normative-types:1.0.0.wd06-SNAPSHOT
+
+template_name: brooklyn.a4c.simple.chatApplication
+template_version: 1.0.0-SNAPSHOT
+
+description: Brooklyn HelloWorld application. (ChatApplication)
+
+node_types:
+  org.apache.brooklyn.entity.webapp.tomcat.TomcatServer:
+    derived_from: tosca.nodes.Root
+    description: >
+      A simple Tomcat server
+    properties:
+      http.port:
+        type: list
+        required: false
+        entry_schema:
+          type: string
+      java.sysprops:
+        type: map
+        required: false
+        entry_schema:
+          type: string
+    artifacts:
+      - wars.root:
+        type: tosca.artifacts.File
+
+topology_template:
+  description: Web Server Sample with Script
+  node_templates:
+    tomcat_server:
+      type: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
+      properties:
+        http.port: "8080+"
+        java.sysprops:
+          brooklyn.example.db.url: $brooklyn:formatString("jdbc:%s%s?user=%s\\&password=%s", component("mysql_server").attributeWhenReady("datastore.url"), "visitors", "brooklyn", "br00k11n")
+      artifacts:
+        wars.root:
+          implementation: "http://search.maven.org/remotecontent?filepath=io/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.6.0/brooklyn-example-hello-world-sql-webapp-0.6.0.war"
+          type: tosca.artifacts.File
+
+
+  # if you want to tell brooklyn to assign a location at deploy time, as part of the template, this is the current way.
+  # it can also be done with camp, referencing this topology template.
+  groups:
+    add_brooklyn_location:
+      members: [ tomcat_server ]
+      policies:
+      - brooklyn.location: localhost


### PR DESCRIPTION
TOSCA manage NodeTemplate's Deployment Artifacts using `artifacts`templates.
Currently, alien4cloud allows to manage this feature. Then, it looks like we could follow
this TOSCA requirement which allows to avoid specifying artifact through entities' properties.

I am not sure, but artifacs could complicate the Brooklyn NodeTypes autogeneration, but I think we could solve using a new Tag, for example `@Artifact`, `@Artifact(main=true)`.
WDYT?
