### PR TITLE
Brooklyn location configurer

### DIFF
--- a/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynCatalogMapper.java
+++ b/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynCatalogMapper.java
@@ -5,7 +5,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import alien4cloud.model.components.*;
 import alien4cloud.tosca.normative.ToscaType;
+import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.brooklyn.rest.client.BrooklynApi;
@@ -22,13 +24,6 @@ import com.google.common.collect.Sets;
 
 import alien4cloud.component.repository.ICsarRepositry;
 import alien4cloud.csar.services.CsarService;
-import alien4cloud.model.components.AttributeDefinition;
-import alien4cloud.model.components.CSARDependency;
-import alien4cloud.model.components.IValue;
-import alien4cloud.model.components.IndexedNodeType;
-import alien4cloud.model.components.Interface;
-import alien4cloud.model.components.Operation;
-import alien4cloud.model.components.PropertyDefinition;
 import alien4cloud.tosca.ArchiveImageLoader;
 import alien4cloud.tosca.ArchiveIndexer;
 import alien4cloud.tosca.model.ArchiveRoot;
@@ -78,8 +73,9 @@ public class BrooklynCatalogMapper {
 
         archiveRoot.getArchive().setDependencies(
                 Sets.newHashSet(
-                    new CSARDependency("tosca-normative-types", "1.0.0.wd03-SNAPSHOT"), 
-                    new CSARDependency("alien4cloud-tomcat-types", "1.0.0-SNAPSHOT")));
+                    new CSARDependency("tosca-normative-types", "1.0.0.wd06-SNAPSHOT"),
+                    new CSARDependency("alien4cloud-tomcat-types", "1.0.0-SNAPSHOT"),
+                    new CSARDependency("brooklyn-types", "0.1.0-SNAPSHOT")));
 
         // TODO Not great way to go but that's a POC for now ;)
         List<CatalogEntitySummary> entities = brooklynApi.getCatalogApi().listEntities(null, null, false);
@@ -116,7 +112,7 @@ public class BrooklynCatalogMapper {
             addPropertyDefinitions(brooklynEntity, toscaType);
             addAttributeDefinitions(brooklynEntity, toscaType);
             addInterfaces(brooklynEntity, toscaType);
-            toscaType.setDerivedFrom(Arrays.asList("tosca.nodes.Root"
+            toscaType.setDerivedFrom(Arrays.asList("brooklyn.nodes.SoftwareProcess"
                 // TODO could introduce this type to mark items from brooklyn (and to give a "b" icon default)
                 //, "brooklyn.tosca.entity.Root"
                 ));

--- a/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynCatalogMapper.java
+++ b/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynCatalogMapper.java
@@ -6,7 +6,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import alien4cloud.model.components.*;
+import alien4cloud.model.components.AttributeDefinition;
+import alien4cloud.model.components.CSARDependency;
+import alien4cloud.model.components.Csar;
+import alien4cloud.model.components.IValue;
+import alien4cloud.model.components.IndexedNodeType;
+import alien4cloud.model.components.Interface;
+import alien4cloud.model.components.Operation;
+import alien4cloud.model.components.PropertyDefinition;
 import alien4cloud.plugin.model.ManagedPlugin;
 import alien4cloud.tosca.ArchiveParser;
 import alien4cloud.tosca.normative.ToscaType;

--- a/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynLocationConfigurer.java
+++ b/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynLocationConfigurer.java
@@ -9,6 +9,7 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import alien4cloud.deployment.matching.services.nodes.MatchingConfigurations;
@@ -38,21 +39,20 @@ import com.google.common.collect.Maps;
 @Component
 public class BrooklynLocationConfigurer implements ILocationConfiguratorPlugin {
 
-
-    @Inject
     private ArchiveParser archiveParser;
-    @Inject
     private MatchingConfigurationsParser matchingConfigurationsParser;
-    @Inject
     private ManagedPlugin selfContext;
-    @Inject
     private TopologyServiceCore topologyService;
 
     private List<PluginArchive> archives;
 
-    @PostConstruct
-    private void postConstruct() {
-        archives = parseArchives();
+    @Autowired
+    public BrooklynLocationConfigurer(ArchiveParser archiveParser, MatchingConfigurationsParser matchingConfigurationsParser, ManagedPlugin selfContext, TopologyServiceCore topologyService) {
+        this.archiveParser = archiveParser;
+        this.matchingConfigurationsParser = matchingConfigurationsParser;
+        this.selfContext = selfContext;
+        this.topologyService = topologyService;
+        this.archives = parseArchives();
     }
 
     private List<PluginArchive> parseArchives() {

--- a/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynLocationConfigurer.java
+++ b/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynLocationConfigurer.java
@@ -1,6 +1,7 @@
 package alien4cloud.brooklyn;
 
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -80,7 +81,7 @@ public class BrooklynLocationConfigurer implements ILocationConfiguratorPlugin {
 
     @Override
     public List<String> getResourcesTypes() {
-        return Lists.newArrayList("brooklyn.nodes.Compute");
+        return Collections.singletonList("brooklyn.nodes.Compute");
     }
 
     @Override
@@ -115,7 +116,6 @@ public class BrooklynLocationConfigurer implements ILocationConfiguratorPlugin {
             String name = StringUtils.isNotBlank(computeContext.getGeneratedNamePrefix()) ? computeContext.getGeneratedNamePrefix()
                     : "BROOKLYN_DEFAULT_COMPUTE_NAME";
             NodeTemplate node = topologyService.buildNodeTemplate(dependencies, indexedNodeType, null);
-            // set the imageId
 
             LocationResourceTemplate resource = new LocationResourceTemplate();
             resource.setService(false);

--- a/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynLocationConfigurer.java
+++ b/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynLocationConfigurer.java
@@ -1,0 +1,129 @@
+package alien4cloud.brooklyn;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import alien4cloud.deployment.matching.services.nodes.MatchingConfigurations;
+import alien4cloud.deployment.matching.services.nodes.MatchingConfigurationsParser;
+import alien4cloud.exception.NotFoundException;
+import alien4cloud.model.components.CSARDependency;
+import alien4cloud.model.components.IndexedNodeType;
+import alien4cloud.model.deployment.matching.MatchingConfiguration;
+import alien4cloud.model.orchestrators.locations.LocationResourceTemplate;
+import alien4cloud.model.topology.NodeTemplate;
+import alien4cloud.orchestrators.locations.services.LocationResourceGeneratorService;
+import alien4cloud.orchestrators.plugin.ILocationConfiguratorPlugin;
+import alien4cloud.orchestrators.plugin.ILocationResourceAccessor;
+import alien4cloud.orchestrators.plugin.model.PluginArchive;
+import alien4cloud.plugin.model.ManagedPlugin;
+import alien4cloud.topology.TopologyServiceCore;
+import alien4cloud.tosca.ArchiveParser;
+import alien4cloud.tosca.model.ArchiveRoot;
+import alien4cloud.tosca.parser.ParsingException;
+import alien4cloud.tosca.parser.ParsingResult;
+import lombok.extern.slf4j.Slf4j;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+@Slf4j
+@Component
+public class BrooklynLocationConfigurer implements ILocationConfiguratorPlugin {
+
+
+    @Inject
+    private ArchiveParser archiveParser;
+    @Inject
+    private MatchingConfigurationsParser matchingConfigurationsParser;
+    @Inject
+    private ManagedPlugin selfContext;
+    @Inject
+    private TopologyServiceCore topologyService;
+
+    private List<PluginArchive> archives;
+
+    @PostConstruct
+    private void postConstruct() {
+        archives = parseArchives();
+    }
+
+    private List<PluginArchive> parseArchives() {
+        List<PluginArchive> archives = Lists.newArrayList();
+        addToAchive(archives, "brooklyn/brooklyn-resources");
+        return archives;
+    }
+
+    private void addToAchive(List<PluginArchive> archives, String path) {
+        Path archivePath = selfContext.getPluginPath().resolve(path);
+        // Parse the archives
+        try {
+            ParsingResult<ArchiveRoot> result = archiveParser.parseDir(archivePath);
+            PluginArchive pluginArchive = new PluginArchive(result.getResult(), archivePath);
+            archives.add(pluginArchive);
+        } catch(ParsingException e) {
+            log.error("Failed to parse archive, plugin won't work as expected", e);
+        }
+    }
+
+    @Override
+    public List<PluginArchive> pluginArchives() {
+        return archives;
+    }
+
+    @Override
+    public List<String> getResourcesTypes() {
+        return Lists.newArrayList("brooklyn.nodes.Compute");
+    }
+
+    @Override
+    public Map<String, MatchingConfiguration> getMatchingConfigurations() {
+        Path matchingConfigPath = selfContext.getPluginPath().resolve("brooklyn/brooklyn-matching-config.yaml");
+        MatchingConfigurations matchingConfigurations;
+        try {
+            matchingConfigurations = matchingConfigurationsParser.parseFile(matchingConfigPath).getResult();
+        } catch(ParsingException e) {
+            return Maps.newHashMap();
+        }
+        return matchingConfigurations.getMatchingConfigurations();
+    }
+
+    @Override
+    public List<LocationResourceTemplate> instances(ILocationResourceAccessor resourceAccessor) {
+        String elementType = "brooklyn.nodes.Compute";
+        LocationResourceGeneratorService.ComputeContext computeContext = new LocationResourceGeneratorService.ComputeContext();
+        Set<CSARDependency> dependencies = resourceAccessor.getDependencies();
+        computeContext.setGeneratedNamePrefix(null);
+
+        try {
+            IndexedNodeType nodeType = resourceAccessor.getIndexedToscaElement(elementType);
+            computeContext.getNodeTypes().add(nodeType);
+        } catch (NotFoundException e) {
+            log.warn("No compute found with the element id: " + elementType, e);
+        }
+
+        List<LocationResourceTemplate> generated = Lists.newArrayList();
+
+        for (IndexedNodeType indexedNodeType : computeContext.getNodeTypes()) {
+            String name = StringUtils.isNotBlank(computeContext.getGeneratedNamePrefix()) ? computeContext.getGeneratedNamePrefix()
+                    : "BROOKLYN_DEFAULT_COMPUTE_NAME";
+            NodeTemplate node = topologyService.buildNodeTemplate(dependencies, indexedNodeType, null);
+            // set the imageId
+
+            LocationResourceTemplate resource = new LocationResourceTemplate();
+            resource.setService(false);
+            resource.setTemplate(node);
+            resource.setName(name);
+
+            generated.add(resource);
+        }
+        return generated;
+    }
+}

--- a/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynLocationConfigurerFactory.java
+++ b/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynLocationConfigurerFactory.java
@@ -1,0 +1,50 @@
+package alien4cloud.brooklyn;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+import alien4cloud.model.deployment.matching.MatchingConfiguration;
+import alien4cloud.model.orchestrators.locations.LocationResourceTemplate;
+import alien4cloud.orchestrators.plugin.ILocationConfiguratorPlugin;
+import alien4cloud.orchestrators.plugin.ILocationResourceAccessor;
+import alien4cloud.orchestrators.plugin.model.PluginArchive;
+
+@Component
+public class BrooklynLocationConfigurerFactory {
+    @Inject
+    private ApplicationContext applicationContext;
+
+    public ILocationConfiguratorPlugin newInstance(String locationType) {
+        if (BrooklynOrchestratorFactory.BROOKLYN.equals(locationType)) {
+            return applicationContext.getBean(BrooklynLocationConfigurer.class);
+        }
+        return new ILocationConfiguratorPlugin() {
+            @Override
+            public List<PluginArchive> pluginArchives() {
+                return new ArrayList<>();
+            }
+
+            @Override
+            public List<String> getResourcesTypes() {
+                return new ArrayList<>();
+            }
+
+            @Override
+            public Map<String, MatchingConfiguration> getMatchingConfigurations() {
+                return new HashMap<>();
+            }
+
+            @Override
+            public List<LocationResourceTemplate> instances(ILocationResourceAccessor resourceAccessor) {
+                return null;
+            }
+        };
+    }
+}

--- a/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynLocationConfigurerFactory.java
+++ b/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynLocationConfigurerFactory.java
@@ -1,6 +1,7 @@
 package alien4cloud.brooklyn;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,22 +29,22 @@ public class BrooklynLocationConfigurerFactory {
         return new ILocationConfiguratorPlugin() {
             @Override
             public List<PluginArchive> pluginArchives() {
-                return new ArrayList<>();
+                return Collections.emptyList();
             }
 
             @Override
             public List<String> getResourcesTypes() {
-                return new ArrayList<>();
+                return Collections.emptyList();
             }
 
             @Override
             public Map<String, MatchingConfiguration> getMatchingConfigurations() {
-                return new HashMap<>();
+                return Collections.emptyMap();
             }
 
             @Override
             public List<LocationResourceTemplate> instances(ILocationResourceAccessor resourceAccessor) {
-                return null;
+                return Collections.emptyList();
             }
         };
     }

--- a/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynOrchestrator.java
+++ b/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynOrchestrator.java
@@ -3,6 +3,8 @@ package alien4cloud.brooklyn;
 import java.util.List;
 import java.util.Map;
 
+import javax.inject.Inject;
+
 import alien4cloud.paas.IPaaSCallback;
 import alien4cloud.paas.model.PaaSDeploymentContext;
 import lombok.extern.slf4j.Slf4j;
@@ -27,31 +29,13 @@ import com.google.common.collect.Maps;
 @Scope(value = "prototype")
 @Slf4j
 public class BrooklynOrchestrator extends BrooklynProvider implements IOrchestratorPlugin<Configuration>, ILocationAutoConfigurer {
+
+    @Inject
+    private BrooklynLocationConfigurerFactory brooklynLocationConfigurerFactory;
     
     @Override
     public ILocationConfiguratorPlugin getConfigurator(String locationType) {
-        return new ILocationConfiguratorPlugin() {
-
-            @Override
-            public List<PluginArchive> pluginArchives() {
-                return Lists.newArrayList();
-            }
-
-            @Override
-            public List<String> getResourcesTypes() {
-                return Lists.newArrayList();
-            }
-
-            @Override
-            public Map<String, MatchingConfiguration> getMatchingConfigurations() {
-                return Maps.newHashMap();
-            }
-
-            @Override
-            public List<LocationResourceTemplate> instances(ILocationResourceAccessor resourceAccessor) {
-                return Lists.newArrayList();
-            }
-        };
+        return brooklynLocationConfigurerFactory.newInstance(locationType);
     }
 
     @Override

--- a/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynOrchestratorFactory.java
+++ b/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynOrchestratorFactory.java
@@ -17,6 +17,8 @@ import alien4cloud.orchestrators.plugin.IOrchestratorPluginFactory;
 @Component("brooklyn-orchestrator-factory")
 public class BrooklynOrchestratorFactory implements IOrchestratorPluginFactory<BrooklynOrchestrator, Configuration> {
 
+    public static final String BROOKLYN = "Brooklyn";
+
     @Autowired
     private BeanFactory beanFactory;
 
@@ -44,7 +46,7 @@ public class BrooklynOrchestratorFactory implements IOrchestratorPluginFactory<B
 
     @Override
     public LocationSupport getLocationSupport() {
-        return new LocationSupport(true, new String[] {});
+        return new LocationSupport(true, new String[] {BROOKLYN});
     }
 
     @Override

--- a/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynProvider.java
+++ b/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynProvider.java
@@ -105,6 +105,7 @@ public abstract class BrooklynProvider implements IConfigurablePaaSProvider<Conf
         try {
             log.info("INIT: " + activeDeployments);
             // TODO synchronise locations
+            catalogMapper.addBaseTypes();
             catalogMapper.mapBrooklynEntities(getNewBrooklynApi());
             
             

--- a/a4c-brooklyn-plugin/src/main/resources/brooklyn/brooklyn-matching-config.yaml
+++ b/a4c-brooklyn-plugin/src/main/resources/brooklyn/brooklyn-matching-config.yaml
@@ -1,0 +1,16 @@
+
+matching_configurations:
+  brooklyn.nodes.Compute:
+    capabilities:
+      - host:
+          properties:
+            - num_cpus: { less_or_equal: 0 } # we match if the template value is less or equal that the location resource value
+            - cpu_frequency: { less_or_equal: 0 Hz }
+            - mem_size: { less_or_equal: 0 B }
+            - disk_size: { less_or_equal: 0 B }
+      - os:
+          properties:
+            - architecture: { equal: "" }
+            - type: { equal: "" }
+            - distribution: { equal: "" }
+            - version: { less_or_equal: "" }

--- a/a4c-brooklyn-plugin/src/main/resources/brooklyn/brooklyn-matching-config.yaml
+++ b/a4c-brooklyn-plugin/src/main/resources/brooklyn/brooklyn-matching-config.yaml
@@ -4,7 +4,7 @@ matching_configurations:
     capabilities:
       - host:
           properties:
-            - num_cpus: { less_or_equal: 0 } # we match if the template value is less or equal that the location resource value
+            - num_cpus: { less_or_equal: 0 }
             - cpu_frequency: { less_or_equal: 0 Hz }
             - mem_size: { less_or_equal: 0 B }
             - disk_size: { less_or_equal: 0 B }

--- a/a4c-brooklyn-plugin/src/main/resources/brooklyn/brooklyn-resources/brooklyn-resources.yaml
+++ b/a4c-brooklyn-plugin/src/main/resources/brooklyn/brooklyn-resources/brooklyn-resources.yaml
@@ -1,0 +1,13 @@
+tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
+
+template_name: brooklyn-types
+template_author: Cloudsoft
+template_version: 0.1.0-SNAPSHOT
+
+description: "Defines resources for the Brooklyn plugin."
+
+imports:
+  - tosca-normative-types:1.0.0.wd06-SNAPSHOT
+node_types:
+  brooklyn.nodes.Compute:
+    derived_from: tosca.nodes.Compute

--- a/a4c-brooklyn-plugin/src/main/resources/brooklyn/brooklyn-resources/brooklyn-resources.yaml
+++ b/a4c-brooklyn-plugin/src/main/resources/brooklyn/brooklyn-resources/brooklyn-resources.yaml
@@ -7,7 +7,15 @@ template_version: 0.1.0-SNAPSHOT
 description: "Defines resources for the Brooklyn plugin."
 
 imports:
-  - tosca-normative-types:1.0.0.wd06-SNAPSHOT
+- tosca-normative-types:1.0.0.wd06-SNAPSHOT
+
 node_types:
   brooklyn.nodes.Compute:
     derived_from: tosca.nodes.Compute
+
+  brooklyn.nodes.SoftwareProcess:
+    derived_from: tosca.nodes.Root
+    requirements:
+    - host: tosca.capabilities.Container
+      relationship: tosca.relationships.HostedOn
+

--- a/a4c-brooklyn-plugin/src/test/java/alien4cloud/brooklyn/PluginTest.java
+++ b/a4c-brooklyn-plugin/src/test/java/alien4cloud/brooklyn/PluginTest.java
@@ -1,10 +1,18 @@
 package alien4cloud.brooklyn;
 
 
+import alien4cloud.deployment.matching.services.nodes.MatchingConfigurationsParser;
+import alien4cloud.plugin.model.ManagedPlugin;
+import alien4cloud.topology.TopologyServiceCore;
+import alien4cloud.tosca.ArchiveParser;
 import lombok.extern.slf4j.Slf4j;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -12,6 +20,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @ContextConfiguration("classpath:test-context.xml")
 @Slf4j
 public class PluginTest {
+
     @Test
     public void testPlugin() {
         log.info("start test");

--- a/a4c-brooklyn-plugin/src/test/java/alien4cloud/brooklyn/TestConfiguration.java
+++ b/a4c-brooklyn-plugin/src/test/java/alien4cloud/brooklyn/TestConfiguration.java
@@ -1,0 +1,20 @@
+package alien4cloud.brooklyn;
+
+import alien4cloud.plugin.model.ManagedPlugin;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+@Configuration
+public class TestConfiguration {
+
+    @Bean
+    public ManagedPlugin managedPlugin() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        Constructor<ManagedPlugin> constructor = ManagedPlugin.class.getDeclaredConstructor(String.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance("");
+    }
+
+}


### PR DESCRIPTION
Defines a implementation of the Abstract `Compute` type specified in tosca-normative-types.  Additionally, defines a `brooklyn.nodes.SoftwareProcess` type that Brooklyn Catalog items are derived from.
