### PR TITLE
Basic relationships support

### DIFF
--- a/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynCatalogMapper.java
+++ b/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynCatalogMapper.java
@@ -156,8 +156,8 @@ public class BrooklynCatalogMapper {
             String derivedFrom = "brooklyn.nodes.SoftwareProcess";
             for (Object tag : brooklynEntity.getRawTags()) {
                 Map<String, ?> tagMap = (Map<String, ?>) tag;
-                if (!tagMap.containsKey("derivedFrom")) continue;
-                derivedFrom = String.valueOf(tagMap.get("derivedFrom"));
+                if (!tagMap.containsKey("tosca:derivedFrom")) continue;
+                derivedFrom = String.valueOf(tagMap.get("tosca:derivedFrom"));
             }
             toscaType.setDerivedFrom(Arrays.asList(derivedFrom));
 
@@ -261,9 +261,9 @@ public class BrooklynCatalogMapper {
     private void addRequirements(CatalogEntitySummary brooklynEntity, IndexedNodeType toscaType) {
         for (Object tag : brooklynEntity.getRawTags()) {
             Map<String, ?> tagMap = (Map<String, ?>) tag;
-            if (!tagMap.containsKey("requirements")) continue;
+            if (!tagMap.containsKey("tosca:requirements")) continue;
             List<RequirementDefinition> requirementDefinitions = MutableList.of();
-            List<Map<String, ?>> requirements = (List<Map<String, ?>>) tagMap.get("requirements");
+            List<Map<String, ?>> requirements = (List<Map<String, ?>>) tagMap.get("tosca:requirements");
             for (Map<String, ?> requirement : requirements) {
                 RequirementDefinition requirementDefinition = new RequirementDefinition(requirement.get("id").toString(), requirement.get("targetType").toString());
                 requirementDefinition.setRelationshipType(requirement.get("relationshipType").toString());
@@ -282,9 +282,9 @@ public class BrooklynCatalogMapper {
     private void addCapabilities(CatalogEntitySummary brooklynEntity, IndexedNodeType toscaType) {
         for (Object tag : brooklynEntity.getRawTags()) {
             Map<String, ?> tagMap = (Map<String, ?>) tag;
-            if (!tagMap.containsKey("capabilities")) continue;
+            if (!tagMap.containsKey("tosca:capabilities")) continue;
             List<CapabilityDefinition> capabilityDefinitions = MutableList.of();
-            List<Map<String, ?>> capabilities = (List<Map<String, ?>>) tagMap.get("capabilities");
+            List<Map<String, ?>> capabilities = (List<Map<String, ?>>) tagMap.get("tosca:capabilities");
             for (Map<String, ?> capability : capabilities) {
                 capabilityDefinitions.add(new CapabilityDefinition(capability.get("id").toString(), capability.get("type").toString(), (Integer) capability.get("upperBound")));
             }

--- a/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynCatalogMapper.java
+++ b/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynCatalogMapper.java
@@ -190,7 +190,11 @@ public class BrooklynCatalogMapper {
                 propertyDefinition.setDescription(entityConfigSummary.getDescription());
                 propertyDefinition.setType(propertyType);
                 if (entityConfigSummary.getDefaultValue() != null) {
-                    propertyDefinition.setDefault(entityConfigSummary.getDefaultValue().toString());
+                    if (propertyType.equals(ToscaType.TIME)) {
+                        propertyDefinition.setDefault(Duration.of(entityConfigSummary.getDefaultValue()).toSeconds() + " s");
+                    } else {
+                        propertyDefinition.setDefault(entityConfigSummary.getDefaultValue().toString());
+                    }
                 }
                 if (ToscaType.MAP.equals(propertyType)) {
                     PropertyDefinition mapDefinition = new PropertyDefinition();
@@ -265,7 +269,7 @@ public class BrooklynCatalogMapper {
             List<RequirementDefinition> requirementDefinitions = MutableList.of();
             List<Map<String, ?>> requirements = (List<Map<String, ?>>) tagMap.get("tosca:requirements");
             for (Map<String, ?> requirement : requirements) {
-                RequirementDefinition requirementDefinition = new RequirementDefinition(requirement.get("id").toString(), requirement.get("targetType").toString());
+                RequirementDefinition requirementDefinition = new RequirementDefinition(requirement.get("id").toString(), requirement.get("capabilityType").toString());
                 requirementDefinition.setRelationshipType(requirement.get("relationshipType").toString());
                 if (requirement.containsKey("lowerBound")) {
                     requirementDefinition.setLowerBound((Integer) requirement.get("lowerBound"));

--- a/a4c-brooklyn-plugin/src/main/resources/brooklyn/brooklyn-resources/brooklyn-resources.yaml
+++ b/a4c-brooklyn-plugin/src/main/resources/brooklyn/brooklyn-resources/brooklyn-resources.yaml
@@ -19,3 +19,20 @@ node_types:
     - host: tosca.capabilities.Container
       relationship: tosca.relationships.HostedOn
 
+  brooklyn.nodes.Database:
+    derived_from: brooklyn.nodes.SoftwareProcess
+
+relationship_types:
+  brooklyn.relationships.Configure:
+    derived_from: tosca.relationships.DependsOn
+    valid_targets: [ tosca.capabilities.Endpoint ]
+    properties:
+      prop.name:
+        type: string
+        required: true
+      prop.value:
+        type: string
+        required: true
+      prop.collection:
+        type: string
+        required: false

--- a/brooklyn-tosca-transformer/src/main/java/org/apache/brooklyn/tosca/a4c/brooklyn/ToscaNodeToEntityConverter.java
+++ b/brooklyn-tosca-transformer/src/main/java/org/apache/brooklyn/tosca/a4c/brooklyn/ToscaNodeToEntityConverter.java
@@ -151,7 +151,7 @@ public class ToscaNodeToEntityConverter {
             RelationshipTemplate relationshipTemplate =
                     findRelationshipRequirement(nodeTemplate, requirementId);
             if((relationshipTemplate!=null)
-                    &&(relationshipTemplate.getType().equals("tosca.relationships.Configure"))){
+                    &&(relationshipTemplate.getType().equals("brooklyn.relationships.Configure"))){
 
                 Map<String, Object> relationProperties = getTemplatePropertyObjects(relationshipTemplate);
 


### PR DESCRIPTION
This adds a basic `brooklyn.relationship.Configure` relationship for a Tomcat / MySQL application on 2 different compute nodes. Also adds support for capabilities and requirements coming from Brooklyn catalog entities.

![alien 4 cloud](https://cloud.githubusercontent.com/assets/2082759/11147696/b882c65a-8a0f-11e5-8f70-58e31480ee3e.png)

![brooklyn js rest client](https://cloud.githubusercontent.com/assets/2082759/11147933/728890ce-8a11-11e5-9af3-159a123dcd0e.png)

![a4c - tomcat component - runtime](https://cloud.githubusercontent.com/assets/2082759/11148086/7674af96-8a12-11e5-969e-d8103baa3ee9.png)

This is dependent [on this PR](https://github.com/apache/incubator-brooklyn/pull/1020). Do no merge before it.
