### PR TITLE
add basic typemapper

### DIFF
--- a/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynOrchestratorFactory.java
+++ b/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/BrooklynOrchestratorFactory.java
@@ -1,9 +1,11 @@
 package alien4cloud.brooklyn;
 
+import java.util.Collections;
 import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.brooklyn.util.collections.MutableList;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -41,7 +43,12 @@ public class BrooklynOrchestratorFactory implements IOrchestratorPluginFactory<B
 
     @Override
     public Configuration getDefaultConfiguration() {
-        return new Configuration("http://localhost:8081/", "brooklyn", "brooklyn", "localhost");
+        return new Configuration("http://localhost:8081/",
+                "brooklyn",
+                "brooklyn",
+                "localhost",
+                MutableList.of("alien4cloud.brooklyn.metadata.DefaultToscaMetadataProvider")
+        );
     }
 
     @Override

--- a/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/Configuration.java
+++ b/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/Configuration.java
@@ -11,11 +11,13 @@ import alien4cloud.ui.form.annotation.FormProperties;
 import alien4cloud.ui.form.annotation.FormPropertyConstraint;
 import alien4cloud.ui.form.annotation.FormPropertyDefinition;
 
+import java.util.List;
+
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@FormProperties({ "url", "user", "password", "location" })
+@FormProperties({ "url", "user", "password", "location", "providers" })
 public class Configuration {
 
     @FormLabel("Brooklyn URL")
@@ -32,4 +34,7 @@ public class Configuration {
 
     @FormLabel("Default Brooklyn Location")
     private String location;
+
+    @FormLabel("Tosca Metadata Providers")
+    private List<String> providers;
 }

--- a/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/metadata/AbstractToscaMetadataProvider.java
+++ b/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/metadata/AbstractToscaMetadataProvider.java
@@ -1,0 +1,21 @@
+package alien4cloud.brooklyn.metadata;
+
+public abstract class AbstractToscaMetadataProvider{
+
+    private AbstractToscaMetadataProvider next;
+
+    public void setNext(AbstractToscaMetadataProvider next){
+        this.next = next;
+    };
+
+    public AbstractToscaMetadataProvider next(){
+        return this.next;
+    }
+
+    public boolean hasNext(){
+        return next != null;
+    }
+
+    public abstract String findToscaType(String type);
+
+}

--- a/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/metadata/DefaultToscaMetadataProvider.java
+++ b/a4c-brooklyn-plugin/src/main/java/alien4cloud/brooklyn/metadata/DefaultToscaMetadataProvider.java
@@ -1,0 +1,25 @@
+package alien4cloud.brooklyn.metadata;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+public class DefaultToscaMetadataProvider extends AbstractToscaMetadataProvider {
+
+    private Map<String, String> typeMapping = ImmutableMap.of(
+            "org.apache.brooklyn.entity.database.mysql.MySqlNode", "brooklyn.nodes.Database"
+    );
+
+    @Override
+    public String findToscaType(String type) {
+        if(!typeMapping.containsKey(type) && !hasNext()) {
+            return "brooklyn.nodes.SoftwareProcess";
+        }
+
+        if(!typeMapping.containsKey(type)){
+            return next().findToscaType(type);
+        }
+
+        return typeMapping.get(type);
+    }
+}

--- a/a4c-brooklyn-plugin/src/main/resources/brooklyn/brooklyn-resources/brooklyn-resources.yaml
+++ b/a4c-brooklyn-plugin/src/main/resources/brooklyn/brooklyn-resources/brooklyn-resources.yaml
@@ -19,3 +19,6 @@ node_types:
     - host: tosca.capabilities.Container
       relationship: tosca.relationships.HostedOn
 
+  brooklyn.nodes.Database:
+    derived_from: brooklyn.nodes.SoftwareProcess
+


### PR DESCRIPTION
Adds a basic type mapper.  Users of a4c configure the plugin through the web ui, specifying MetadataProvider classes, which are on the classpath, in a list.  The plugin then instantiates these and searches through each in turn to find the metadata.  
