### PR TITLE
Features/brooklyn policies support

### DIFF
--- a/brooklyn-tosca-transformer/src/main/java/org/apache/brooklyn/tosca/a4c/brooklyn/ToscaPlanToSpecTransformer.java
+++ b/brooklyn-tosca-transformer/src/main/java/org/apache/brooklyn/tosca/a4c/brooklyn/ToscaPlanToSpecTransformer.java
@@ -241,7 +241,7 @@ public class ToscaPlanToSpecTransformer implements PlanToSpecTransformer {
             throw new IllegalStateException("Type was nof found for policy " + policy.getName());
         }
 
-        ImmutableMap policies = ImmutableMap.of(
+        ImmutableMap policyDefinition = ImmutableMap.of(
                 BrooklynCampReservedKeys.BROOKLYN_POLICIES, ImmutableList.of(
                         ImmutableMap.of(
                                 "policyType", type,
@@ -254,7 +254,12 @@ public class ToscaPlanToSpecTransformer implements PlanToSpecTransformer {
                         " defined by policy " + policy.getName() + " was not found");
             }
             new BrooklynEntityDecorationResolver.PolicySpecResolver(yamlLoader)
-                    .decorate(spec, ConfigBag.newInstance(policies));
+                    .decorate(spec, ConfigBag.newInstance(policyDefinition));
+        }
+
+        if(group.getMembers()==null || group.getMembers().isEmpty()){
+            new BrooklynEntityDecorationResolver.PolicySpecResolver(yamlLoader)
+                    .decorate(appSpec, ConfigBag.newInstance(policyDefinition));
         }
     }
 

--- a/brooklyn-tosca-transformer/src/test/java/org/apache/brooklyn/tosca/a4c/Alien4CloudToscaTest.java
+++ b/brooklyn-tosca-transformer/src/test/java/org/apache/brooklyn/tosca/a4c/Alien4CloudToscaTest.java
@@ -1,20 +1,9 @@
 package org.apache.brooklyn.tosca.a4c;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import com.google.common.collect.Iterables;
-import org.apache.brooklyn.api.entity.Application;
-import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.camp.CampPlatform;
-import org.apache.brooklyn.camp.brooklyn.BrooklynCampConstants;
 import org.apache.brooklyn.camp.brooklyn.BrooklynCampPlatformLauncherNoServer;
-import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
-import org.apache.brooklyn.util.guava.SerializablePredicate;
 import org.testng.annotations.BeforeMethod;
-
-import javax.annotation.Nullable;
 
 public class Alien4CloudToscaTest extends BrooklynAppUnitTestSupport {
 
@@ -32,44 +21,6 @@ public class Alien4CloudToscaTest extends BrooklynAppUnitTestSupport {
 
     public String getClasspathUrlForResource(String resourceName){
         return "classpath://"+ resourceName;
-    }
-
-    public static EntitySpec<?> findChildEntitySpecByPlanId(EntitySpec<? extends Application> app, String planId){
-
-        Optional<EntitySpec<?>> result = Iterables.tryFind(app.getChildren(),
-                configSatisfies(BrooklynCampConstants.PLAN_ID, planId));
-
-        if (result.isPresent()) {
-            return result.get();
-        }
-        //TODO: better NoSuchElementException? return null?
-        throw new IllegalStateException("Entity with planId  " + planId + " is not contained on" +
-                " ApplicationSpec "+ app +" children");
-    }
-
-    public static <T> Predicate<EntitySpec> configSatisfies(final ConfigKey<T> configKey, final T val) {
-        return new ConfigKeySatisfies<T>(configKey, Predicates.equalTo(val));
-    }
-
-    protected static class ConfigKeySatisfies<T> implements SerializablePredicate<EntitySpec> {
-        protected final ConfigKey<T> configKey;
-        protected final Predicate<T> condition;
-
-        private ConfigKeySatisfies(ConfigKey<T> configKey, Predicate<T> condition) {
-            this.configKey = configKey;
-            this.condition = condition;
-        }
-
-        @Override
-        @SuppressWarnings("unchecked")
-        public boolean apply(@Nullable EntitySpec input) {
-            return (input != null) && condition.apply((T)input.getConfig().get(configKey));
-        }
-
-        @Override
-        public String toString() {
-            return "configKeySatisfies("+configKey.getName()+","+condition+")";
-        }
     }
 
 }

--- a/brooklyn-tosca-transformer/src/test/resources/templates/autoscaling.policies.tosca.yaml
+++ b/brooklyn-tosca-transformer/src/test/resources/templates/autoscaling.policies.tosca.yaml
@@ -1,0 +1,36 @@
+tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
+
+imports:
+  - tosca-normative-types:1.0.0.wd03-SNAPSHOT
+
+template_name: brooklyn.a4c.simple.simple-autoscaler-policy
+template_version: 1.0.0-SNAPSHOT
+
+description: Dynamic cluster with an AutoScalerPolicy
+
+node_types:
+  org.apache.brooklyn.entity.webapp.DynamicWebAppCluster:
+    derived_from: tosca.nodes.Root
+    description: >
+      A simple Dynamic Cluster
+
+topology_template:
+  description: Dynamic Cluster and a austoscaling policy
+  node_templates:
+    cluster:
+      type: org.apache.brooklyn.entity.webapp.DynamicWebAppCluster
+
+  # if you want to tell brooklyn to assign a location at deploy time, as part of the template, this is the current way.
+  # it can also be done with camp, referencing this topology template.
+  groups:
+    add_brooklyn_location:
+      members: [ cluster ]
+      policies:
+        - brooklyn.location: localhost
+        - autoscaling:
+            type: org.apache.brooklyn.policy.autoscaling.AutoScalerPolicy
+            metric: $brooklyn:sensor("org.apache.brooklyn.entity.webapp.DynamicWebAppCluster", "webapp.reqs.perSec.windowed.perNode")
+            metricLowerBound: 10
+            metricUpperBound: 100
+            minPoolSize: 1
+            maxPoolSize: 5

--- a/brooklyn-tosca-transformer/src/test/resources/templates/compute1.tosca.yaml
+++ b/brooklyn-tosca-transformer/src/test/resources/templates/compute1.tosca.yaml
@@ -9,7 +9,7 @@ imports:
  template_version: 1.0.0-SNAPSHOT
 
 description: Template for deploying a single server with predefined properties.
- 
+
 topology_template:
   node_templates:
     my_server:

--- a/brooklyn-tosca-transformer/src/test/resources/templates/simple.application-policies.tosca.yaml
+++ b/brooklyn-tosca-transformer/src/test/resources/templates/simple.application-policies.tosca.yaml
@@ -1,0 +1,34 @@
+tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
+
+imports:
+  - tosca-normative-types:1.0.0.wd03-SNAPSHOT
+
+template_name: brooklyn.a4c.simple.simple-autoscaler-policy
+template_version: 1.0.0-SNAPSHOT
+
+description: Dynamic cluster with an AutoScalerPolicy
+
+node_types:
+  org.apache.brooklyn.entity.webapp.DynamicWebAppCluster:
+    derived_from: tosca.nodes.Root
+    description: >
+      A simple Dynamic Cluster
+
+topology_template:
+  description: Dynamic Cluster and a austoscaling policy
+  node_templates:
+    cluster:
+      type: org.apache.brooklyn.entity.webapp.DynamicWebAppCluster
+
+  # if you want to tell brooklyn to assign a location at deploy time, as part of the template, this is the current way.
+  # it can also be done with camp, referencing this topology template.
+  groups:
+    add_brooklyn_location:
+      members: [ ]
+      policies:
+        - test-policy:
+            type: org.apache.brooklyn.core.test.policy.TestPolicy
+            policyLiteralValue1: Hello
+            policyLiteralValue2: World
+            test.confName: Name from YAML
+            test.confFromFunction:  "$brooklyn:formatString(\"%s: is a fun place\", \"$brooklyn\")"


### PR DESCRIPTION
Adding brooklyn policies support.

It is a first version of brooklyn policies support.
Camp engine was used as a first approach.
As placement policies, a brooklyn policy can be added to any Node (entity).
Moreover, application policies are added. Then, an application whole can contain a brooklyn policy.
Check [example](https://github.com/cloudsoft/brooklyn-tosca/blob/79a20d5d8f1fa58bd0b924f35741cfa7275515db/brooklyn-tosca-transformer/src/test/resources/templates/simple.application-policies.tosca.yaml).
