### PR TITLE
Remove TARGET relationship hack

### DIFF
--- a/brooklyn-tosca-transformer/src/test/resources/templates/relationship.yaml
+++ b/brooklyn-tosca-transformer/src/test/resources/templates/relationship.yaml
@@ -76,7 +76,7 @@ topology_template:
             properties:
               prop.collection: java.sysprops
               prop.name: brooklyn.example.db.url
-              prop.value: $brooklyn:formatString("jdbc:%s%s?user=%s\\&password=%s", TARGET.attributeWhenReady("datastore.url"), "visitors", "brooklyn", "br00k11n")
+              prop.value: $brooklyn:formatString("jdbc:%s%s?user=%s\\&password=%s", $brooklyn:component("mysql_server").attributeWhenReady("datastore.url"), "visitors", "brooklyn", "br00k11n")
 
     mysql_server:
       type: org.apache.brooklyn.entity.database.mysql.MySqlNode


### PR DESCRIPTION
Drop magic replacement of "TARGET" in favour of requiring that blueprint writers use `$brooklyn:component("...")` directly when defining relationships and their values. 

Most changes are formatting. 
