### PR TITLE
brooklyn-tosca can be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Then simply:
 ## Running
 
 See the README.md file in the resulting archive (in `target`) for runtime instructions.
-You may also find that file [here](src/main/assembly/files/README.md).
+You may also find that file [here](brooklyn-tosca-dist/src/main/assembly/files/README.md).
 
 
 ## TODO Tasks

--- a/brooklyn-tosca-dist/src/main/assembly/files/README.md
+++ b/brooklyn-tosca-dist/src/main/assembly/files/README.md
@@ -50,13 +50,21 @@ Any ElasticSearch data stored by this instance will use default ES file location
 The recommended way to configure ES data is by launching a separate Alien4Cloud instance 
 configured as desired, with this instance pointing at that.
 
+### Quickstart: TOSCA disabled
+
+If you wish to start Brooklyn with TOSCA modules disabled then run:
+
+    nohup ./brooklyn.sh launch -Dbrooklyn.experimental.feature.tosca=false
+
+You may also set `brooklyn.experimental.feature.tosca` in your `brooklyn.properties` file.
+
 
 ## Supported TOSCA Syntax
 
 This currently supports nearly all TOSCA elements at parse time, 
 and the following at deploy time:
 
-* `tosca.nodes.Compute` nodes for VM's
+* `tosca.nodes.Compute` nodes for VMs
 * Other node types which define `standard` lifecycle `interfaces` as scripts by URL, 
   optionally declaring their `host` requirement pointing at a compute node template
 

--- a/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/brooklyn/EnablementTest.java
+++ b/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/brooklyn/EnablementTest.java
@@ -1,0 +1,73 @@
+package io.cloudsoft.tosca.a4c.brooklyn;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
+import org.apache.brooklyn.api.entity.Application;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.camp.brooklyn.BrooklynCampPlatformLauncherNoServer;
+import org.apache.brooklyn.camp.brooklyn.spi.creation.CampTypePlanTransformer;
+import org.apache.brooklyn.core.BrooklynFeatureEnablement;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.typereg.RegisteredTypeLoadingContexts;
+import org.apache.brooklyn.util.core.ResourceUtils;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Predicates;
+
+import io.cloudsoft.tosca.a4c.Alien4CloudToscaPlatform;
+
+public class EnablementTest extends BrooklynAppUnitTestSupport {
+
+    @Test(expectedExceptions = {IllegalStateException.class})
+    public void testTransformerRejectsBlueprintWhenFeatureDisabled() throws Exception {
+        BrooklynFeatureEnablement.disable(ToscaPlanToSpecTransformer.FEATURE_TOSCA_ENABLED);
+        try {
+            Alien4CloudToscaPlatform.grantAdminAuth();
+            Alien4CloudToscaPlatform platform = Alien4CloudToscaPlatform.newInstance();
+            mgmt.getBrooklynProperties().put(ToscaPlanToSpecTransformer.TOSCA_ALIEN_PLATFORM, platform);
+            platform.loadNormativeTypes();
+            ToscaPlanToSpecTransformer transformer = new ToscaPlanToSpecTransformer();
+            transformer.setManagementContext(mgmt);
+
+            // Should throw.
+            transformer.createApplicationSpec(
+                    new ResourceUtils(mgmt).getResourceAsString("classpath://templates/helloworld-sql.tosca.yaml"));
+        } finally {
+            BrooklynFeatureEnablement.enable(ToscaPlanToSpecTransformer.FEATURE_TOSCA_ENABLED);
+        }
+    }
+
+    @Test
+    public void testCreateSpecFromPlanFailsWhenFeatureDisabled() throws Exception {
+        BrooklynFeatureEnablement.disable(ToscaPlanToSpecTransformer.FEATURE_TOSCA_ENABLED);
+        try {
+            Alien4CloudToscaPlatform.grantAdminAuth();
+            Alien4CloudToscaPlatform platform = Alien4CloudToscaPlatform.newInstance();
+            mgmt.getBrooklynProperties().put(ToscaPlanToSpecTransformer.TOSCA_ALIEN_PLATFORM, platform);
+            platform.loadNormativeTypes();
+            ToscaPlanToSpecTransformer transformer = new ToscaPlanToSpecTransformer();
+            transformer.setManagementContext(mgmt);
+
+            new BrooklynCampPlatformLauncherNoServer()
+                    .useManagementContext(mgmt)
+                    .launch()
+                    .getCampPlatform();
+
+            try {
+                mgmt.getTypeRegistry().createSpecFromPlan(CampTypePlanTransformer.FORMAT,
+                        new ResourceUtils(mgmt).getResourceAsString("classpath://templates/helloworld-sql.tosca.yaml"),
+                        RegisteredTypeLoadingContexts.spec(Application.class),
+                        EntitySpec.class);
+                fail("Expected spec creation to fail because tosca was disabled");
+            } catch (Exception e) {
+                final Throwable firstInteresting = Exceptions.getFirstThrowableMatching(e, Predicates.instanceOf(IllegalStateException.class));
+                assertNotNull(firstInteresting, "Expected " + IllegalStateException.class.getName());
+            }
+
+        } finally {
+            BrooklynFeatureEnablement.enable(ToscaPlanToSpecTransformer.FEATURE_TOSCA_ENABLED);
+        }
+    }
+}


### PR DESCRIPTION
Either give `-Dbrooklyn.experimental.feature.tosca=false` or set the property in brooklyn.properties.
