### PR TITLE
PlanToSpecTransformer throws PlanNotRecognisedException rather than IllegalState

### DIFF
--- a/brooklyn-tosca-dist/src/main/assembly/assembly.xml
+++ b/brooklyn-tosca-dist/src/main/assembly/assembly.xml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-    
-     http://www.apache.org/licenses/LICENSE-2.0
-    
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
--->
 <assembly>
     <id>dist</id>
     <!-- Generates an archive and a dir containing the needed files; 

--- a/brooklyn-tosca-dist/src/main/assembly/scripts/brooklyn.sh
+++ b/brooklyn-tosca-dist/src/main/assembly/scripts/brooklyn.sh
@@ -1,22 +1,4 @@
 #!/bin/bash
-#
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#  http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-#
 
 if [ ! -z "$JAVA_HOME" ] ; then 
     JAVA=$JAVA_HOME/bin/java

--- a/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/TosacEntitySpecResolver.java
+++ b/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/TosacEntitySpecResolver.java
@@ -6,11 +6,11 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.mgmt.classloading.BrooklynClassLoadingContext;
 import org.apache.brooklyn.core.resolve.entity.AbstractEntitySpecResolver;
 
-public class Alien4CloudEntitySpecResolver extends AbstractEntitySpecResolver {
+public class TosacEntitySpecResolver extends AbstractEntitySpecResolver {
 
     private static final String RESOLVER_NAME = "alien4cloud_deployment_topology";
 
-    public Alien4CloudEntitySpecResolver() {
+    public TosacEntitySpecResolver() {
         super(RESOLVER_NAME);
     }
 

--- a/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaPlanToSpecTransformer.java
+++ b/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaPlanToSpecTransformer.java
@@ -289,7 +289,6 @@ public class ToscaPlanToSpecTransformer implements PlanToSpecTransformer {
         case ENTITY:
             // unwrap? any other processing?
             return (SpecT) createApplicationSpec(item.getPlanYaml());
-            
         case LOCATION: 
         case POLICY:
             throw new PlanNotRecognizedException("TOSCA does not support: "+item.getCatalogItemType());
@@ -308,9 +307,9 @@ public class ToscaPlanToSpecTransformer implements PlanToSpecTransformer {
      */
     private void assertAvailable() {
         if (!BrooklynFeatureEnablement.isEnabled(FEATURE_TOSCA_ENABLED)) {
-            throw new IllegalStateException("Brooklyn TOSCA support is disabled");
+            throw new PlanNotRecognizedException("Brooklyn TOSCA support is disabled");
         } else if (!alienInitialised.get()) {
-            throw new IllegalStateException("A4C platform is uninitialised for " + this);
+            throw new PlanNotRecognizedException("Alien4Cloud platform is uninitialised for " + this);
         }
     }
 

--- a/brooklyn-tosca-transformer/src/main/resources/META-INF/services/org.apache.brooklyn.core.plan.PlanToSpecTransformer
+++ b/brooklyn-tosca-transformer/src/main/resources/META-INF/services/org.apache.brooklyn.core.plan.PlanToSpecTransformer
@@ -1,19 +1,1 @@
-#
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements. See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership. The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied. See the License for the
-# specific language governing permissions and limitations
-# under the License.
-#
 io.cloudsoft.tosca.a4c.brooklyn.ToscaPlanToSpecTransformer

--- a/brooklyn-tosca-transformer/src/main/resources/META-INF/services/org.apache.brooklyn.core.resolve.entity.EntitySpecResolver
+++ b/brooklyn-tosca-transformer/src/main/resources/META-INF/services/org.apache.brooklyn.core.resolve.entity.EntitySpecResolver
@@ -1,19 +1,1 @@
-#
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#  http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-#
 io.cloudsoft.tosca.a4c.brooklyn.Alien4CloudEntitySpecResolver

--- a/brooklyn-tosca-transformer/src/main/resources/META-INF/services/org.apache.brooklyn.core.resolve.entity.EntitySpecResolver
+++ b/brooklyn-tosca-transformer/src/main/resources/META-INF/services/org.apache.brooklyn.core.resolve.entity.EntitySpecResolver
@@ -1,1 +1,1 @@
-io.cloudsoft.tosca.a4c.brooklyn.Alien4CloudEntitySpecResolver
+io.cloudsoft.tosca.a4c.brooklyn.TosacEntitySpecResolver

--- a/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/brooklyn/EnablementIntegrationTest.java
+++ b/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/brooklyn/EnablementIntegrationTest.java
@@ -8,6 +8,7 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.camp.brooklyn.BrooklynCampPlatformLauncherNoServer;
 import org.apache.brooklyn.camp.brooklyn.spi.creation.CampTypePlanTransformer;
 import org.apache.brooklyn.core.BrooklynFeatureEnablement;
+import org.apache.brooklyn.core.plan.PlanNotRecognizedException;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.typereg.RegisteredTypeLoadingContexts;
 import org.apache.brooklyn.util.core.ResourceUtils;
@@ -21,7 +22,7 @@ import io.cloudsoft.tosca.a4c.platform.Alien4CloudToscaPlatform;
 
 public class EnablementIntegrationTest extends Alien4CloudIntegrationTest {
 
-    @Test(expectedExceptions = {IllegalStateException.class})
+    @Test(expectedExceptions = {PlanNotRecognizedException.class})
     public void testTransformerRejectsBlueprintWhenFeatureDisabled() throws Exception {
         BrooklynFeatureEnablement.disable(ToscaPlanToSpecTransformer.FEATURE_TOSCA_ENABLED);
         try {
@@ -47,7 +48,6 @@ public class EnablementIntegrationTest extends Alien4CloudIntegrationTest {
                 final Throwable firstInteresting = Exceptions.getFirstThrowableMatching(e, Predicates.instanceOf(IllegalStateException.class));
                 assertNotNull(firstInteresting, "Expected " + IllegalStateException.class.getName());
             }
-
         } finally {
             BrooklynFeatureEnablement.enable(ToscaPlanToSpecTransformer.FEATURE_TOSCA_ENABLED);
         }


### PR DESCRIPTION
Brooklyn's `PlanToSpecFactory` treats `PlanNotRecognizedException` differently to other exceptions. 
