### PR TITLE
Make default types configurable

### DIFF
--- a/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/ConfigLoader.java
+++ b/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/ConfigLoader.java
@@ -1,0 +1,22 @@
+package io.cloudsoft.tosca.a4c.brooklyn;
+
+import java.util.List;
+
+import org.apache.brooklyn.util.core.ResourceUtils;
+import org.apache.brooklyn.util.yaml.Yamls;
+
+import com.google.common.collect.ImmutableList;
+
+public class ConfigLoader {
+
+    private static final String CONFIG_URL = "classpath://brooklyn/brooklyn-tosca-config.yaml";
+
+    private ConfigLoader() {}
+
+    @SuppressWarnings("unchecked")
+    public static Iterable<String> getDefaultTypes() {
+        String input = new ResourceUtils(null).getResourceAsString(CONFIG_URL);
+        return (List) Yamls.getAt(input, ImmutableList.of("defaultTypes"));
+    }
+
+}

--- a/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaPlanToSpecTransformer.java
+++ b/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaPlanToSpecTransformer.java
@@ -56,7 +56,8 @@ public class ToscaPlanToSpecTransformer implements PlanToSpecTransformer {
     private static final Logger log = LoggerFactory.getLogger(ToscaPlanToSpecTransformer.class);
     
     public static final ConfigKey<Alien4CloudToscaPlatform> TOSCA_ALIEN_PLATFORM = ConfigKeys.builder(Alien4CloudToscaPlatform.class)
-        .name("tosca.a4c.platform").build();
+            .name("tosca.a4c.platform")
+            .build();
 
     @VisibleForTesting
     static final String FEATURE_TOSCA_ENABLED = BrooklynFeatureEnablement.FEATURE_PROPERTY_PREFIX + ".tosca";
@@ -94,7 +95,7 @@ public class ToscaPlanToSpecTransformer implements PlanToSpecTransformer {
         }
     }
 
-    private void initialiseAlien(){
+    private void initialiseAlien() {
         try {
             synchronized (ToscaPlanToSpecTransformer.class) {
                 platform = mgmt.getConfig().getConfig(TOSCA_ALIEN_PLATFORM);
@@ -103,7 +104,6 @@ public class ToscaPlanToSpecTransformer implements PlanToSpecTransformer {
                     ApplicationContext applicationContext = Alien4CloudSpringContext.newApplicationContext(mgmt);
                     platform = applicationContext.getBean(Alien4CloudToscaPlatform.class);
                     ((LocalManagementContext) mgmt).getBrooklynProperties().put(TOSCA_ALIEN_PLATFORM, platform);
-                    platform.loadNormativeTypes();
                 }
             }
             alienInitialised.set(true);

--- a/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/platform/Alien4CloudSpringConfig.java
+++ b/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/platform/Alien4CloudSpringConfig.java
@@ -28,7 +28,7 @@ import alien4cloud.security.ResourceRoleService;
 public class Alien4CloudSpringConfig {
 
     @Bean
-    public ResourceRoleService getDummyRRS() {
+    public ResourceRoleService getDummyRoleResourceService() {
         return new ResourceRoleService();
     }
 

--- a/brooklyn-tosca-transformer/src/main/resources/brooklyn/brooklyn-tosca-config.yaml
+++ b/brooklyn-tosca-transformer/src/main/resources/brooklyn/brooklyn-tosca-config.yaml
@@ -1,0 +1,4 @@
+# A list of resources that contain TOSCA type definitions and that should be
+# loaded by the plugin on initialisation.
+defaultTypes:
+- https://github.com/alien4cloud/tosca-normative-types/archive/master.zip

--- a/brooklyn-tosca-transformer/src/main/resources/logback-custom.xml
+++ b/brooklyn-tosca-transformer/src/main/resources/logback-custom.xml
@@ -5,7 +5,7 @@
     <property name="logging.basename" scope="context" value="brooklyn-tosca" />
 
     <!-- include everything in this project at debug level -->
-    <logger name="org.apache.brooklyn.tosca" level="DEBUG"/>
+    <logger name="io.cloudsoft.tosca" level="DEBUG"/>
 
     <!-- include the alien appender -->
     <include resource="brooklyn/logback-appender-alien.xml"/>

--- a/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/Alien4CloudIntegrationTest.java
+++ b/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/Alien4CloudIntegrationTest.java
@@ -35,7 +35,6 @@ public class Alien4CloudIntegrationTest extends AbstractTestNGSpringContextTests
         assertNotNull(super.applicationContext, "No application context for test");
         Alien4CloudToscaPlatform.grantAdminAuth();
         this.platform = super.applicationContext.getBean(Alien4CloudToscaPlatform.class);
-        platform.loadNormativeTypes();
         mgmt = super.applicationContext.getBean(ManagementContext.class);
         assertNotNull(mgmt, "No management context found for test");
         ((ManagementContextInternal) mgmt).getBrooklynProperties().put(ToscaPlanToSpecTransformer.TOSCA_ALIEN_PLATFORM, platform);

--- a/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/brooklyn/AlienSamplesLiveTest.java
+++ b/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/brooklyn/AlienSamplesLiveTest.java
@@ -26,7 +26,6 @@ public class AlienSamplesLiveTest extends Alien4CloudToscaLiveTest {
     private static final Logger LOG = LoggerFactory.getLogger(AlienSamplesLiveTest.class);
     private static final String DEFAULT_LOCATION_SPEC = "aws-ec2:eu-west-1";
     private static String RESOURCE_LOC = "classpath://templates";
-    public static final String ALIEN_SAMPLE_TYPES_GITHUB_URL = "https://github.com/alien4cloud/samples/archive/1.1.0-SM8.zip";
 
     protected ToscaPlanToSpecTransformer transformer;
     private Alien4CloudToscaPlatform platform;
@@ -41,7 +40,6 @@ public class AlienSamplesLiveTest extends Alien4CloudToscaLiveTest {
         ApplicationContext applicationContext = Alien4CloudSpringContext.newApplicationContext(mgmt);
         platform = applicationContext.getBean(Alien4CloudToscaPlatform.class);
         mgmt.getBrooklynProperties().put(ToscaPlanToSpecTransformer.TOSCA_ALIEN_PLATFORM, platform);
-        platform.loadNormativeTypes();
         transformer = new ToscaPlanToSpecTransformer();
         transformer.setManagementContext(mgmt);
         platform.uploadSingleYaml(new ResourceUtils(platform).getResourceFromUrl("brooklyn-resources.yaml"), "brooklyn-resources");
@@ -103,7 +101,6 @@ public class AlienSamplesLiveTest extends Alien4CloudToscaLiveTest {
     }
 
     public Entity createAndManageFrom(String zipName, String template, TestApplication app) throws Exception {
-        platform.loadTypesFromUrl(ALIEN_SAMPLE_TYPES_GITHUB_URL, true);
         String templateUrl = RESOURCE_LOC + "/" + template;
         EntitySpec<?> spec = transformer.createApplicationSpec(
                 new ResourceUtils(mgmt).getResourceAsString(templateUrl));

--- a/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaPlanToSpecTransformerIntegrationTest.java
+++ b/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaPlanToSpecTransformerIntegrationTest.java
@@ -250,7 +250,6 @@ public class ToscaPlanToSpecTransformerIntegrationTest extends Alien4CloudIntegr
     public void testMysqlTopology() throws Exception {
         try {
             platform.uploadSingleYaml(new ResourceUtils(platform).getResourceFromUrl("brooklyn-resources.yaml"), "brooklyn-resources");
-            platform.loadTypesFromUrl(AlienSamplesLiveTest.ALIEN_SAMPLE_TYPES_GITHUB_URL, true);
 
             String templateUrl = "classpath://templates/mysql-topology.tosca.yaml";
 
@@ -310,9 +309,7 @@ public class ToscaPlanToSpecTransformerIntegrationTest extends Alien4CloudIntegr
     @Test
     public void testOverwriteInterfaceOnMysqlTopology() throws Exception {
         try {
-
             platform.uploadSingleYaml(new ResourceUtils(platform).getResourceFromUrl("brooklyn-resources.yaml"), "brooklyn-resources");
-            platform.loadTypesFromUrl(AlienSamplesLiveTest.ALIEN_SAMPLE_TYPES_GITHUB_URL, true);
 
             String templateUrl = "classpath://templates/mysql-topology-overwritten-interface.tosca.yaml";
 

--- a/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/platform/Alien4CloudToscaPlatformIntegrationTest.java
+++ b/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/platform/Alien4CloudToscaPlatformIntegrationTest.java
@@ -36,8 +36,6 @@ public class Alien4CloudToscaPlatformIntegrationTest extends Alien4CloudIntegrat
         ApplicationContext applicationContext = Alien4CloudSpringContext.newApplicationContext(new LocalManagementContext());
         Alien4CloudToscaPlatform platform = applicationContext.getBean(Alien4CloudToscaPlatform.class);
         
-        platform.loadNormativeTypes();
-        
         String name = "simple-web-server.yaml";
         String url = "classpath://templates/" + name;
         ParsingResult<Csar> tp = platform.uploadSingleYaml(new ResourceUtils(platform).getResourceFromUrl(url), name);
@@ -66,7 +64,7 @@ public class Alien4CloudToscaPlatformIntegrationTest extends Alien4CloudIntegrat
     }
 
     public ParsingResult<ArchiveRoot> sampleParseTosca(Alien4CloudToscaPlatform platform) throws Exception {
-        ToscaParser parser = platform.getToscaParser();
+        ToscaParser parser = platform.getBean(ToscaParser.class);
         ParsingResult<ArchiveRoot> tp = parser.parseFile("<classpath>", "pizza.tosca",
             new ResourceUtils(this).getResourceFromUrl("classpath://templates/pizza.tosca.yaml"), null);
         return tp;
@@ -75,7 +73,7 @@ public class Alien4CloudToscaPlatformIntegrationTest extends Alien4CloudIntegrat
     @Test
     public void testCanParseSampleTosca() throws Exception {
         try {
-            ParsingResult<ArchiveRoot> tp = new Alien4CloudToscaPlatformIntegrationTest().sampleParseTosca(platform);
+            ParsingResult<ArchiveRoot> tp = sampleParseTosca(platform);
             Assert.assertTrue( tp.getResult().getNodeTypes().containsKey("tosca.nodes.WebApplication.PayPalPizzaStore") );
         } finally {
             if (platform!=null) platform.close();

--- a/brooklyn-tosca-transformer/src/test/resources/brooklyn/brooklyn-tosca-config.yaml
+++ b/brooklyn-tosca-transformer/src/test/resources/brooklyn/brooklyn-tosca-config.yaml
@@ -1,0 +1,4 @@
+# Overrides version in src/main to include samples.
+defaultTypes:
+- https://github.com/alien4cloud/tosca-normative-types/archive/master.zip
+- https://github.com/alien4cloud/samples/archive/1.1.0-SM8.zip


### PR DESCRIPTION
The set of archives to import when initialising a server may be configured by editing `brooklyn-tosca-config.yaml`. `Alien4CloudToscaPlatform.loadNormativeTypes` is replaced by `loadDefaultTypes`, which is called by the class constructor.
