### PR TITLE
Fix/dsl management in policies

### DIFF
--- a/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/AbstractToscaPolicyDecorator.java
+++ b/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/AbstractToscaPolicyDecorator.java
@@ -1,19 +1,60 @@
 package io.cloudsoft.tosca.a4c.brooklyn;
 
-import java.util.Map;
-
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.camp.brooklyn.spi.creation.CampCatalogUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
+
+import java.util.Map;
 
 public abstract class AbstractToscaPolicyDecorator implements ToscaPolicyDecorator {
 
+    protected ManagementContext mgmt;
+
+    public AbstractToscaPolicyDecorator(ManagementContext mgmt) {
+        this.mgmt = mgmt;
+    }
+
     /**
      * Returns policy properties. In this case, type or name are not considered as properties.
+     *
      * @param policyData
      */
-    public Map<String, ?> getPolicyProperties(Map<String, ?> policyData){
+    public Map<String, ?> getPolicyProperties(Map<String, ?> policyData) {
         Map<String, ?> data = MutableMap.copyOf(policyData);
         data.remove(POLICY_FLAG_NAME);
         data.remove(POLICY_FLAG_TYPE);
-        return data;
+        return resolveProperties(data);
     }
+
+    private Map<String, Object> resolveProperties(Map<String, ?> policyProperties) {
+        Map<String, Object> resolvedPolicyProperties = MutableMap.of();
+        for (Map.Entry<String, ?> entry : policyProperties.entrySet()) {
+            Optional<Object> resolvedValue =
+                    resolveValue(entry.getValue(), Optional.<TypeToken>absent());
+            if (resolvedValue.isPresent()) {
+                resolvedPolicyProperties.put(entry.getKey(), resolvedValue.get());
+            } else {
+                resolvedPolicyProperties.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return resolvedPolicyProperties;
+    }
+
+    private Optional<Object> resolveValue(Object unresolvedValue, Optional<TypeToken> desiredType) {
+        if (unresolvedValue == null) {
+            return Optional.absent();
+        }
+        // The 'dsl' key is arbitrary, but the interpreter requires a map
+        Map<String, Object> resolvedConfigMap = CampCatalogUtils.getCampPlatform(mgmt)
+                .pdp()
+                .applyInterpreters(ImmutableMap.of("dsl", unresolvedValue));
+        return Optional.of(desiredType.isPresent()
+                ? TypeCoercions.coerce(resolvedConfigMap.get("dsl"), desiredType.get())
+                : resolvedConfigMap.get("dsl"));
+    }
+
 }

--- a/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/BrooklynToscaPolicyDecorator.java
+++ b/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/BrooklynToscaPolicyDecorator.java
@@ -3,7 +3,6 @@ package io.cloudsoft.tosca.a4c.brooklyn;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 import io.cloudsoft.tosca.a4c.brooklyn.util.EntitySpecs;
 import org.apache.brooklyn.api.entity.Application;
 import org.apache.brooklyn.api.entity.EntitySpec;
@@ -12,11 +11,8 @@ import org.apache.brooklyn.api.mgmt.classloading.BrooklynClassLoadingContext;
 import org.apache.brooklyn.camp.brooklyn.BrooklynCampReservedKeys;
 import org.apache.brooklyn.camp.brooklyn.spi.creation.BrooklynEntityDecorationResolver;
 import org.apache.brooklyn.camp.brooklyn.spi.creation.BrooklynYamlTypeInstantiator;
-import org.apache.brooklyn.camp.brooklyn.spi.creation.CampCatalogUtils;
 import org.apache.brooklyn.core.mgmt.classloading.JavaBrooklynClassLoadingContext;
-import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
-import org.apache.brooklyn.util.core.flags.TypeCoercions;
 
 import java.util.List;
 import java.util.Map;
@@ -25,11 +21,10 @@ import java.util.Set;
 public class BrooklynToscaPolicyDecorator extends AbstractToscaPolicyDecorator {
 
     private EntitySpec<? extends Application> rootSpec;
-    private ManagementContext mgmt;
 
     BrooklynToscaPolicyDecorator(EntitySpec<? extends Application> rootSpec, ManagementContext mgmt) {
+        super(mgmt);
         this.rootSpec = rootSpec;
-        this.mgmt = mgmt;
     }
 
     public void decorate(Map<String, ?> policyData, String policyName, Optional<String> type, Set<String> groupMembers) {
@@ -41,11 +36,9 @@ public class BrooklynToscaPolicyDecorator extends AbstractToscaPolicyDecorator {
     }
 
     private ConfigBag getPolicyDefinition(String type, Map<String, ?> policyData) {
-
-        Map<String, ?> unresolvedProperties = getPolicyProperties(policyData);
         List<?> policies = ImmutableList.of(ImmutableMap.of(
                         "policyType", type,
-                        BrooklynCampReservedKeys.BROOKLYN_CONFIG, resolveProperties(unresolvedProperties)
+                        BrooklynCampReservedKeys.BROOKLYN_CONFIG, getPolicyProperties(policyData)
                 )
         );
         Map<?, ?> policyDefinition = ImmutableMap.of(BrooklynCampReservedKeys.BROOKLYN_POLICIES, policies);
@@ -73,33 +66,6 @@ public class BrooklynToscaPolicyDecorator extends AbstractToscaPolicyDecorator {
 
     private void decorateWithPolicy(BrooklynYamlTypeInstantiator.Factory yamlLoader, EntitySpec<?> spec, ConfigBag policyDefinition) {
         new BrooklynEntityDecorationResolver.PolicySpecResolver(yamlLoader).decorate(spec, policyDefinition);
-    }
-
-    private Map<String, Object> resolveProperties(Map<String, ?> policyProperties) {
-        Map<String, Object> resolvedPolicyProperties = MutableMap.of();
-        for (Map.Entry<String, ?> entry : policyProperties.entrySet()) {
-            Optional<Object> resolvedValue =
-                    resolveValue(entry.getValue(), Optional.<TypeToken>absent());
-            if (resolvedValue.isPresent()) {
-                resolvedPolicyProperties.put(entry.getKey(), resolvedValue.get());
-            } else {
-                resolvedPolicyProperties.put(entry.getKey(), entry.getValue());
-            }
-        }
-        return resolvedPolicyProperties;
-    }
-
-    protected Optional<Object> resolveValue(Object unresolvedValue, Optional<TypeToken> desiredType) {
-        if (unresolvedValue == null) {
-            return Optional.absent();
-        }
-        // The 'dsl' key is arbitrary, but the interpreter requires a map
-        Map<String, Object> resolvedConfigMap = CampCatalogUtils.getCampPlatform(mgmt)
-                .pdp()
-                .applyInterpreters(ImmutableMap.of("dsl", unresolvedValue));
-        return Optional.of(desiredType.isPresent()
-                ? TypeCoercions.coerce(resolvedConfigMap.get("dsl"), desiredType.get())
-                : resolvedConfigMap.get("dsl"));
     }
 
 }

--- a/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/BrooklynToscaPolicyDecorator.java
+++ b/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/BrooklynToscaPolicyDecorator.java
@@ -1,9 +1,10 @@
 package io.cloudsoft.tosca.a4c.brooklyn;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+import io.cloudsoft.tosca.a4c.brooklyn.util.EntitySpecs;
 import org.apache.brooklyn.api.entity.Application;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
@@ -11,17 +12,17 @@ import org.apache.brooklyn.api.mgmt.classloading.BrooklynClassLoadingContext;
 import org.apache.brooklyn.camp.brooklyn.BrooklynCampReservedKeys;
 import org.apache.brooklyn.camp.brooklyn.spi.creation.BrooklynEntityDecorationResolver;
 import org.apache.brooklyn.camp.brooklyn.spi.creation.BrooklynYamlTypeInstantiator;
+import org.apache.brooklyn.camp.brooklyn.spi.creation.CampCatalogUtils;
 import org.apache.brooklyn.core.mgmt.classloading.JavaBrooklynClassLoadingContext;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-import io.cloudsoft.tosca.a4c.brooklyn.util.EntitySpecs;
-
-public class BrooklynToscaPolicyDecorator extends AbstractToscaPolicyDecorator{
+public class BrooklynToscaPolicyDecorator extends AbstractToscaPolicyDecorator {
 
     private EntitySpec<? extends Application> rootSpec;
     private ManagementContext mgmt;
@@ -40,16 +41,18 @@ public class BrooklynToscaPolicyDecorator extends AbstractToscaPolicyDecorator{
     }
 
     private ConfigBag getPolicyDefinition(String type, Map<String, ?> policyData) {
+
+        Map<String, ?> unresolvedProperties = getPolicyProperties(policyData);
         List<?> policies = ImmutableList.of(ImmutableMap.of(
-                "policyType", type,
-                BrooklynCampReservedKeys.BROOKLYN_CONFIG, getPolicyProperties(policyData)
+                        "policyType", type,
+                        BrooklynCampReservedKeys.BROOKLYN_CONFIG, resolveProperties(unresolvedProperties)
                 )
         );
         Map<?, ?> policyDefinition = ImmutableMap.of(BrooklynCampReservedKeys.BROOKLYN_POLICIES, policies);
         return ConfigBag.newInstance(policyDefinition);
     }
 
-    private void decorateEntityBrooklynWithPolicies(EntitySpec<? extends Application> appSpec, Set<String> groupMembers, ConfigBag policyDefinition, String policyName){
+    private void decorateEntityBrooklynWithPolicies(EntitySpec<? extends Application> appSpec, Set<String> groupMembers, ConfigBag policyDefinition, String policyName) {
         BrooklynClassLoadingContext loader = JavaBrooklynClassLoadingContext.create(mgmt);
         BrooklynYamlTypeInstantiator.Factory yamlLoader = new BrooklynYamlTypeInstantiator.Factory(loader, this);
 
@@ -58,7 +61,7 @@ public class BrooklynToscaPolicyDecorator extends AbstractToscaPolicyDecorator{
             return;
         }
 
-        for (String specId: groupMembers){
+        for (String specId : groupMembers) {
             EntitySpec<?> spec = EntitySpecs.findChildEntitySpecByPlanId(appSpec, specId);
             if (spec == null) {
                 throw new IllegalStateException("Error: NodeTemplate " + specId +
@@ -71,4 +74,32 @@ public class BrooklynToscaPolicyDecorator extends AbstractToscaPolicyDecorator{
     private void decorateWithPolicy(BrooklynYamlTypeInstantiator.Factory yamlLoader, EntitySpec<?> spec, ConfigBag policyDefinition) {
         new BrooklynEntityDecorationResolver.PolicySpecResolver(yamlLoader).decorate(spec, policyDefinition);
     }
+
+    private Map<String, Object> resolveProperties(Map<String, ?> policyProperties) {
+        Map<String, Object> resolvedPolicyProperties = MutableMap.of();
+        for (Map.Entry<String, ?> entry : policyProperties.entrySet()) {
+            Optional<Object> resolvedValue =
+                    resolveValue(entry.getValue(), Optional.<TypeToken>absent());
+            if (resolvedValue.isPresent()) {
+                resolvedPolicyProperties.put(entry.getKey(), resolvedValue.get());
+            } else {
+                resolvedPolicyProperties.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return resolvedPolicyProperties;
+    }
+
+    protected Optional<Object> resolveValue(Object unresolvedValue, Optional<TypeToken> desiredType) {
+        if (unresolvedValue == null) {
+            return Optional.absent();
+        }
+        // The 'dsl' key is arbitrary, but the interpreter requires a map
+        Map<String, Object> resolvedConfigMap = CampCatalogUtils.getCampPlatform(mgmt)
+                .pdp()
+                .applyInterpreters(ImmutableMap.of("dsl", unresolvedValue));
+        return Optional.of(desiredType.isPresent()
+                ? TypeCoercions.coerce(resolvedConfigMap.get("dsl"), desiredType.get())
+                : resolvedConfigMap.get("dsl"));
+    }
+
 }

--- a/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/LocationToscaPolicyDecorator.java
+++ b/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/LocationToscaPolicyDecorator.java
@@ -1,27 +1,24 @@
 package io.cloudsoft.tosca.a4c.brooklyn;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
+import alien4cloud.tosca.parser.impl.advanced.GroupPolicyParser;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.camp.brooklyn.spi.creation.BrooklynYamlLocationResolver;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableMap;
-
-import alien4cloud.tosca.parser.impl.advanced.GroupPolicyParser;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class LocationToscaPolicyDecorator extends AbstractToscaPolicyDecorator {
 
     private Map<String, EntitySpec<?>> specs;
-    private ManagementContext mgmt;
 
     LocationToscaPolicyDecorator(Map<String, EntitySpec<?>> specs, ManagementContext mgmt) {
+        super(mgmt);
         this.specs = specs;
-        this.mgmt = mgmt;
     }
 
     public void decorate(Map<String, ?> policyData, String policyName, Optional<String> type, Set<String> groupMembers) {

--- a/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaTypePlanTransformerIntegrationTest.java
+++ b/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaTypePlanTransformerIntegrationTest.java
@@ -32,6 +32,7 @@ import org.apache.brooklyn.entity.software.base.SameServerEntity;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess;
 import org.apache.brooklyn.entity.stock.BasicApplication;
+import org.apache.brooklyn.entity.webapp.DynamicWebAppCluster;
 import org.apache.brooklyn.entity.webapp.tomcat.TomcatServer;
 import org.apache.brooklyn.location.byon.FixedListMachineProvisioningLocation;
 import org.apache.brooklyn.location.jclouds.JcloudsLocation;
@@ -219,10 +220,10 @@ public class ToscaTypePlanTransformerIntegrationTest extends Alien4CloudIntegrat
                 .findChildEntitySpecByPlanId(app, "tomcat_server");
 
         assertNotNull(tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS));
-        assertEquals(((Map)tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS)).size(), 2);
+        assertEquals(((Map) tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS)).size(), 2);
         assertEquals(((Map)tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS))
                 .get("dbConnection1").toString(), "connection1");
-        assertEquals(((Map)tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS))
+        assertEquals(((Map) tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS))
                 .get("dbConnection2").toString(), "connection2");
     }
 
@@ -245,9 +246,8 @@ public class ToscaTypePlanTransformerIntegrationTest extends Alien4CloudIntegrat
         assertEquals(autoScalerPolicyFlags.get("metricUpperBound"), "100");
         assertEquals(autoScalerPolicyFlags.get("minPoolSize"), "1");
         assertEquals(autoScalerPolicyFlags.get("maxPoolSize"), "5");
-        assertEquals(autoScalerPolicyFlags.get("metric"), "$brooklyn:sensor(" +
-                "\"org.apache.brooklyn.entity.webapp.DynamicWebAppCluster\"," +
-                " \"webapp.reqs.perSec.windowed.perNode\")");
+        assertEquals(autoScalerPolicyFlags.get("metric"),
+                DynamicWebAppCluster.REQUESTS_PER_SECOND_IN_WINDOW_PER_NODE);
     }
 
     @Test
@@ -266,8 +266,7 @@ public class ToscaTypePlanTransformerIntegrationTest extends Alien4CloudIntegrat
         assertEquals(testPolicyFlags.get("policyLiteralValue1"), "Hello");
         assertEquals(testPolicyFlags.get("policyLiteralValue2"), "World");
         assertEquals(testPolicyFlags.get("test.confName"), "Name from YAML");
-        assertEquals(testPolicyFlags.get("test.confFromFunction"),
-                "$brooklyn:formatString(\"%s: is a fun place\", \"$brooklyn\")");
+        assertEquals(testPolicyFlags.get("test.confFromFunction"), "$brooklyn: is a fun place");
     }
 
     @Test

--- a/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaTypePlanTransformerIntegrationTest.java
+++ b/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaTypePlanTransformerIntegrationTest.java
@@ -370,7 +370,7 @@ public class ToscaTypePlanTransformerIntegrationTest extends Alien4CloudIntegrat
                 "expected " + TomcatServer.class.getName() + " in " + appChild.getChildren());
     }
 
-    @Test
+    @Test(enabled = false)
     public void testConcatFunctionInTopology() throws Exception {
         EntitySpec<? extends Application> spec = create("classpath://templates/concat-function.yaml");
 


### PR DESCRIPTION
Interprets DSL in policy properties.
 `testConcatFunctionInTopology()` was disabled according to [alien4cloud/alien4cloud#68](https://github.com/alien4cloud/alien4cloud/issues/68)
