### PR TITLE
Improve chained relations management

### DIFF
--- a/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/spec/RelationshipModifier.java
+++ b/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/spec/RelationshipModifier.java
@@ -8,6 +8,7 @@ import javax.inject.Inject;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.BrooklynDslCommon;
+import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
@@ -65,7 +66,9 @@ public class RelationshipModifier extends ConfigKeyModifier {
                     }
                 }
             }
-            joinPropertiesAndValueTypes(propertiesAndTypedValues, getToscaFacade().getPropertiesAndTypeValuesByRelationshipId(relationship.getSourceNodeId(), toscaApplication, relationship.getRelationshipId(), computeName));
+            if(relationship.getSourceNodeId().equals(nodeId)){
+                joinPropertiesAndValueTypes(propertiesAndTypedValues, getToscaFacade().getPropertiesAndTypeValuesByRelationshipId(relationship.getSourceNodeId(), toscaApplication, relationship.getRelationshipId(), computeName));
+            }
         }
         configureConfigKeysSpec(entitySpec, ConfigBag.newInstance(propertiesAndTypedValues));
     }

--- a/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaTypePlanTransformerIntegrationTest.java
+++ b/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaTypePlanTransformerIntegrationTest.java
@@ -467,4 +467,26 @@ public class ToscaTypePlanTransformerIntegrationTest extends Alien4CloudIntegrat
         assertEquals(compute.getType(), SameServerEntity.class);
     }
 
+    @Test(enabled = true)
+    public void testChainedRelations() throws Exception {
+        EntitySpec<? extends Application> app = create("classpath://templates/chained-relations-frontend-backend-db.yml");
+        assertNotNull(app);
+
+        assertEquals(app.getChildren().size(), 3);
+
+        EntitySpec<?> frontend = EntitySpecs
+                .findChildEntitySpecByPlanId(app, "frontend");
+        EntitySpec<?> backend = EntitySpecs
+                .findChildEntitySpecByPlanId(app, "backend");
+
+        assertNotNull(frontend.getConfig().get(TomcatServer.JAVA_SYSPROPS));
+        assertEquals(((Map) frontend.getConfig().get(TomcatServer.JAVA_SYSPROPS)).size(), 1);
+        assertEquals(((Map) frontend.getConfig().get(TomcatServer.JAVA_SYSPROPS))
+                .get("brooklyn.example.backend.endpoint").toString(), "$brooklyn:entity(\"backend\").attributeWhenReady(\"webapp.url\")");
+
+        assertNotNull(backend.getConfig().get(TomcatServer.JAVA_SYSPROPS));
+        assertEquals(((Map) backend.getConfig().get(TomcatServer.JAVA_SYSPROPS)).size(), 1);
+        assertEquals(((Map) backend.getConfig().get(TomcatServer.JAVA_SYSPROPS))
+                .get("brooklyn.example.db.url").toString(), DATABASE_DEPENDENCY_INJECTION);
+    }
 }

--- a/brooklyn-tosca-transformer/src/test/resources/templates/chained-relations-frontend-backend-db.yml
+++ b/brooklyn-tosca-transformer/src/test/resources/templates/chained-relations-frontend-backend-db.yml
@@ -1,0 +1,105 @@
+tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
+
+imports:
+  - tosca-normative-types:1.0.0.wd06-SNAPSHOT
+
+template_name: frontend-backend-database-application
+template_version: 1.0.0-SNAPSHOT
+
+description: Application composed by a frondend, a backend and a database
+
+relationship_types:
+  brooklyn.relationships.Configure:
+    derived_from: tosca.relationships.DependsOn
+    valid_targets: [ tosca.capabilities.Endpoint ]
+    properties:
+      prop.name:
+        type: string
+        required: false
+      prop.value:
+        type: string
+        required: true
+      prop.collection:
+        type: string
+        required: false
+
+node_types:
+  org.apache.brooklyn.entity.webapp.tomcat.TomcatServer:
+    derived_from: tosca.nodes.Root
+    description: >
+      A simple Tomcat server
+    properties:
+      wars.root:
+        type: string
+        required: false
+      http.port:
+        type: list
+        required: false
+        entry_schema:
+          type: string
+      java.sysprops:
+        type: map
+        required: false
+        entry_schema:
+          type: string
+    capabilities:
+      endpoint_configuration: tosca.capabilities.Endpoint
+    requirements:
+      - dbConnection: tosca.nodes.Root
+        type: brooklyn.relationships.Configure
+        lower_bound: 0
+        upper_bound: unbounded
+      - endpoint_configuration: tosca.nodes.Root
+        type: brooklyn.relationships.Configure
+        lower_bound: 0
+        upper_bound: unbounded
+
+  org.apache.brooklyn.entity.database.mysql.MySqlNode:
+    derived_from: tosca.nodes.Root
+    description: |
+      A MySQL server
+    properties:
+      creationScriptUrl:
+        type: string
+        required: false
+    capabilities:
+      dbConnection: tosca.capabilities.Endpoint.Database
+
+topology_template:
+  description:
+  node_templates:
+
+    frontend:
+      type: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
+      requirements:
+        - endpoint_configuration:
+            node: backend
+            relationship: brooklyn.relationships.Configure
+            properties:
+              prop.collection: java.sysprops
+              prop.name: brooklyn.example.backend.endpoint
+              prop.value: $brooklyn:component("backend").attributeWhenReady("webapp.url")
+
+    backend:
+      type: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
+      requirements:
+        - dbConnection:
+            node: mysql_server
+            relationship: brooklyn.relationships.Configure
+            properties:
+              prop.collection: java.sysprops
+              prop.name: brooklyn.example.db.url
+              prop.value: $brooklyn:formatString("jdbc:%s%s?user=%s\\&password=%s", $brooklyn:component("mysql_server").attributeWhenReady("datastore.url"), "visitors", "brooklyn", "br00k11n")
+
+    mysql_server:
+      type: org.apache.brooklyn.entity.database.mysql.MySqlNode
+
+
+  # if you want to tell brooklyn to assign a location at deploy time, as part of the template, this is the current way.
+  # it can also be done with camp, referencing this topology template.
+  groups:
+    add_brooklyn_location:
+      members: [ frontend , backend , mysql_server ]
+      policies:
+      - brooklyn.location: localhost
+


### PR DESCRIPTION
When some nodeTemplate are related, ensure that only Source EntitySpecs properties will be configured.

When relations are managed, if an entity was source **and** target of some relations  then necssary properties to configure the input and output relations, properties (`ConfigKeys`), was being added to target EntitySpecs.

For example, in the following `topology_template`:

```
    frontend:
      type: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
      requirements:
        - endpoint_configuration:
            node: backend
            relationship: brooklyn.relationships.Configure
            properties:
              prop.collection: java.sysprops
              prop.name: brooklyn.example.backend.endpoint
              prop.value: $brooklyn:component("backend").attributeWhenReady("webapp.url")

    backend:
      type: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
      requirements:
        - dbConnection:
            node: mysql_server
            relationship: brooklyn.relationships.Configure
            properties:
              prop.collection: java.sysprops
              prop.name: brooklyn.example.db.url
              prop.value: $brooklyn:formatString("jdbc:%s%s?user=%s\\&password=%s", $brooklyn:component("mysql_server").attributeWhenReady("datastore.url"), "visitors", "brooklyn", "br00k11n")

    mysql_server:
      type: org.apache.brooklyn.entity.database.mysql.MySqlNode
```

`backend` has to be configured  for `dbConnection`. The, problem was that `backend` is source and target of two different relations, so `ConfigKey` for `fronted.endpoint_configuration` configuration was also added to `backend` EntitySpec. Then, `backend.getConfig().get(TomcatServer.JAVA_SYSPROPS)` had two entries `brooklyn.example.backend.endpoint` and `brooklyn.example.db.url`, which is not expected.
