### PR TITLE
Fix/relations override prop collections

### DIFF
--- a/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaTypePlanTransformerIntegrationTest.java
+++ b/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaTypePlanTransformerIntegrationTest.java
@@ -178,7 +178,7 @@ public class ToscaTypePlanTransformerIntegrationTest extends Alien4CloudIntegrat
 
 
     @Test
-    public void testRelationNotReplacePropColectionConfigKey()
+    public void testRelationNotOverridePropCollectionConfigKey()
             throws ParsingException, CSARVersionAlreadyExistsException, IOException {
 
         Path outputPath = makeOutputPath("relationship-defined-prop-collection.yaml", "relation", "test.sh", "target.sh");
@@ -196,6 +196,28 @@ public class ToscaTypePlanTransformerIntegrationTest extends Alien4CloudIntegrat
         assertEquals(((Map) tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS))
                 .get("brooklyn.example.db.url").toString(), DATABASE_DEPENDENCY_INJECTION);
         assertEquals(((Map) tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS))
+                .get("key1").toString(), "value1");
+    }
+
+    @Test
+    public void testRelationNotOverridePropCollectionFlag()
+            throws ParsingException, CSARVersionAlreadyExistsException, IOException {
+
+        Path outputPath = makeOutputPath("relationship-defined-prop-collection-flag.yaml", "relation", "test.sh", "target.sh");
+        ToscaApplication toscaApplication = platform.parse(outputPath);
+        EntitySpec<? extends Application> app = transformer.createApplicationSpec(toscaApplication);
+
+        assertNotNull(app);
+        assertEquals(app.getChildren().size(), 2);
+
+        EntitySpec<?> tomcatServer = EntitySpecs
+                .findChildEntitySpecByPlanId(app, "tomcat_server");
+
+        assertNotNull(tomcatServer.getFlags().get("javaSysProps"));
+        assertEquals(((Map) tomcatServer.getFlags().get("javaSysProps")).size(), 2);
+        assertEquals(((Map) tomcatServer.getFlags().get("javaSysProps"))
+                .get("brooklyn.example.db.url").toString(), DATABASE_DEPENDENCY_INJECTION);
+        assertEquals(((Map) tomcatServer.getFlags().get("javaSysProps"))
                 .get("key1").toString(), "value1");
     }
 

--- a/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaTypePlanTransformerIntegrationTest.java
+++ b/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaTypePlanTransformerIntegrationTest.java
@@ -1,14 +1,20 @@
 package io.cloudsoft.tosca.a4c.brooklyn;
 
-import alien4cloud.component.repository.exception.CSARVersionAlreadyExistsException;
-import alien4cloud.tosca.parser.ParsingException;
-import alien4cloud.utils.FileUtil;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
-import com.google.common.io.Files;
-import io.cloudsoft.tosca.a4c.Alien4CloudIntegrationTest;
-import io.cloudsoft.tosca.a4c.brooklyn.util.EntitySpecs;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
 import org.apache.brooklyn.api.entity.Application;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
@@ -33,19 +39,16 @@ import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.stream.Streams;
 import org.testng.annotations.Test;
 
-import javax.annotation.Nullable;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.io.Files;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+import alien4cloud.component.repository.exception.CSARVersionAlreadyExistsException;
+import alien4cloud.tosca.parser.ParsingException;
+import alien4cloud.utils.FileUtil;
+import io.cloudsoft.tosca.a4c.Alien4CloudIntegrationTest;
+import io.cloudsoft.tosca.a4c.brooklyn.util.EntitySpecs;
 
 public class ToscaTypePlanTransformerIntegrationTest extends Alien4CloudIntegrationTest {
 
@@ -179,12 +182,9 @@ public class ToscaTypePlanTransformerIntegrationTest extends Alien4CloudIntegrat
 
     @Test
     public void testRelationNotOverridePropCollectionConfigKey()
-            throws ParsingException, CSARVersionAlreadyExistsException, IOException {
+            throws Exception {
 
-        Path outputPath = makeOutputPath("relationship-defined-prop-collection.yaml", "relation", "test.sh", "target.sh");
-        ToscaApplication toscaApplication = platform.parse(outputPath);
-        EntitySpec<? extends Application> app = transformer.createApplicationSpec(toscaApplication);
-
+        EntitySpec<? extends Application> app = create("classpath://templates/relationship-defined-prop-collection.yaml");
         assertNotNull(app);
         assertEquals(app.getChildren().size(), 2);
 
@@ -192,21 +192,18 @@ public class ToscaTypePlanTransformerIntegrationTest extends Alien4CloudIntegrat
                 .findChildEntitySpecByPlanId(app, "tomcat_server");
 
         assertNotNull(tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS));
+        
+        
         assertEquals(((Map) tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS)).size(), 2);
-        assertEquals(((Map) tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS))
-                .get("brooklyn.example.db.url").toString(), DATABASE_DEPENDENCY_INJECTION);
-        assertEquals(((Map) tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS))
-                .get("key1").toString(), "value1");
+        assertEquals(((Map) tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS)).get("brooklyn.example.db.url").toString(), DATABASE_DEPENDENCY_INJECTION);
+        assertEquals(((Map) tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS)).get("key1").toString(), "value1");
     }
 
-    @Test
+    @Test(enabled = true)
     public void testRelationNotOverridePropCollectionFlag()
-            throws ParsingException, CSARVersionAlreadyExistsException, IOException {
+            throws Exception {
 
-        Path outputPath = makeOutputPath("relationship-defined-prop-collection-flag.yaml", "relation", "test.sh", "target.sh");
-        ToscaApplication toscaApplication = platform.parse(outputPath);
-        EntitySpec<? extends Application> app = transformer.createApplicationSpec(toscaApplication);
-
+        EntitySpec<? extends Application> app = create("classpath://templates/relationship-defined-prop-collection-flag.yaml");
         assertNotNull(app);
         assertEquals(app.getChildren().size(), 2);
 
@@ -250,10 +247,8 @@ public class ToscaTypePlanTransformerIntegrationTest extends Alien4CloudIntegrat
 
         assertNotNull(tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS));
         assertEquals(((Map) tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS)).size(), 2);
-        assertEquals(((Map) tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS))
-                .get("dbConnection1").toString(), "connection1");
-        assertEquals(((Map) tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS))
-                .get("dbConnection2").toString(), "connection2");
+        assertEquals(((Map) tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS)).get("dbConnection1").toString(), "connection1");
+        assertEquals(((Map) tomcatServer.getConfig().get(TomcatServer.JAVA_SYSPROPS)).get("dbConnection2").toString(), "connection2");
     }
 
     @Test

--- a/brooklyn-tosca-transformer/src/test/resources/templates/relationship-defined-prop-collection-flag.yaml
+++ b/brooklyn-tosca-transformer/src/test/resources/templates/relationship-defined-prop-collection-flag.yaml
@@ -22,15 +22,6 @@ relationship_types:
       prop.collection:
         type: string
         required: false
-    interfaces:
-      Configure:
-        pre_configure_source:
-          inputs:
-            DB_IP: { get_attribute: [TARGET, ip_address] }
-          implementation: scripts/test.sh
-        pre_configure_target:
-          implementation: scripts/target.sh
-
 
 node_types:
   org.apache.brooklyn.entity.webapp.tomcat.TomcatServer:

--- a/brooklyn-tosca-transformer/src/test/resources/templates/relationship-defined-prop-collection-flag.yaml
+++ b/brooklyn-tosca-transformer/src/test/resources/templates/relationship-defined-prop-collection-flag.yaml
@@ -1,0 +1,98 @@
+tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
+
+imports:
+  - tosca-normative-types:1.0.0.wd06-SNAPSHOT
+
+template_name: brooklyn.a4c.simple.chatApplication
+template_version: 1.0.0-SNAPSHOT
+
+description: Brooklyn HelloWorld application. (ChatApplication)
+
+relationship_types:
+  brooklyn.relationships.Configure:
+    derived_from: tosca.relationships.DependsOn
+    valid_targets: [ tosca.capabilities.Endpoint ]
+    properties:
+      prop.name:
+        type: string
+        required: false
+      prop.value:
+        type: string
+        required: true
+      prop.collection:
+        type: string
+        required: false
+    interfaces:
+      Configure:
+        pre_configure_source:
+          inputs:
+            DB_IP: { get_attribute: [TARGET, ip_address] }
+          implementation: scripts/test.sh
+        pre_configure_target:
+          implementation: scripts/target.sh
+
+
+node_types:
+  org.apache.brooklyn.entity.webapp.tomcat.TomcatServer:
+    derived_from: tosca.nodes.Root
+    description: >
+      A simple Tomcat server
+    properties:
+      wars.root:
+        type: string
+        required: false
+      http.port:
+        type: list
+        required: false
+        entry_schema:
+          type: string
+      javaSysProps:
+        type: map
+        required: false
+        entry_schema:
+          type: string
+    requirements:
+      - dbConnection: tosca.nodes.Root
+        type: brooklyn.relationships.Configure
+
+  org.apache.brooklyn.entity.database.mysql.MySqlNode:
+    derived_from: tosca.nodes.Root
+    description: >
+      A MySQL server
+    properties:
+      "datastore.creation.script.url":
+        type: string
+        required: false
+    capabilities:
+      dbConnection: tosca.capabilities.Endpoint.Database
+
+
+topology_template:
+  description: Web Server Sample with Script
+  node_templates:
+    tomcat_server:
+      type: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
+      properties:
+        wars.root: "http://search.maven.org/remotecontent?filepath=io/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.6.0/brooklyn-example-hello-world-sql-webapp-0.6.0.war"
+        http.port: "8080+"
+        javaSysProps:
+          key1: value1
+      requirements:
+        - dbConnection:
+            node: mysql_server
+            relationship: brooklyn.relationships.Configure
+            properties:
+              prop.collection: javaSysProps
+              prop.name: brooklyn.example.db.url
+              prop.value: $brooklyn:formatString("jdbc:%s%s?user=%s\\&password=%s", $brooklyn:component("mysql_server").attributeWhenReady("datastore.url"), "visitors", "brooklyn", "br00k11n")
+
+    mysql_server:
+      type: org.apache.brooklyn.entity.database.mysql.MySqlNode
+      properties:
+        datastore.creation.script.url: "https://raw.githubusercontent.com/apache/incubator-brooklyn/286448623c417f099a8bce1a4764d6aa4589c6ea/brooklyn-server/launcher/src/test/resources/visitors-creation-script.sql"
+
+  groups:
+    add_brooklyn_location:
+      members: [ mysql_server, tomcat_server ]
+      policies:
+      - brooklyn.location: localhost

--- a/brooklyn-tosca-transformer/src/test/resources/templates/relationship-defined-prop-collection.yaml
+++ b/brooklyn-tosca-transformer/src/test/resources/templates/relationship-defined-prop-collection.yaml
@@ -22,14 +22,6 @@ relationship_types:
       prop.collection:
         type: string
         required: false
-    interfaces:
-      Configure:
-        pre_configure_source:
-          inputs:
-            DB_IP: { get_attribute: [TARGET, ip_address] }
-          implementation: scripts/test.sh
-        pre_configure_target:
-          implementation: scripts/target.sh
 
 
 node_types:

--- a/brooklyn-tosca-transformer/src/test/resources/templates/relationship-defined-prop-collection.yaml
+++ b/brooklyn-tosca-transformer/src/test/resources/templates/relationship-defined-prop-collection.yaml
@@ -1,0 +1,98 @@
+tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
+
+imports:
+  - tosca-normative-types:1.0.0.wd06-SNAPSHOT
+
+template_name: brooklyn.a4c.simple.chatApplication
+template_version: 1.0.0-SNAPSHOT
+
+description: Brooklyn HelloWorld application. (ChatApplication)
+
+relationship_types:
+  brooklyn.relationships.Configure:
+    derived_from: tosca.relationships.DependsOn
+    valid_targets: [ tosca.capabilities.Endpoint ]
+    properties:
+      prop.name:
+        type: string
+        required: false
+      prop.value:
+        type: string
+        required: true
+      prop.collection:
+        type: string
+        required: false
+    interfaces:
+      Configure:
+        pre_configure_source:
+          inputs:
+            DB_IP: { get_attribute: [TARGET, ip_address] }
+          implementation: scripts/test.sh
+        pre_configure_target:
+          implementation: scripts/target.sh
+
+
+node_types:
+  org.apache.brooklyn.entity.webapp.tomcat.TomcatServer:
+    derived_from: tosca.nodes.Root
+    description: >
+      A simple Tomcat server
+    properties:
+      wars.root:
+        type: string
+        required: false
+      http.port:
+        type: list
+        required: false
+        entry_schema:
+          type: string
+      java.sysprops:
+        type: map
+        required: false
+        entry_schema:
+          type: string
+    requirements:
+      - dbConnection: tosca.nodes.Root
+        type: brooklyn.relationships.Configure
+
+  org.apache.brooklyn.entity.database.mysql.MySqlNode:
+    derived_from: tosca.nodes.Root
+    description: >
+      A MySQL server
+    properties:
+      "datastore.creation.script.url":
+        type: string
+        required: false
+    capabilities:
+      dbConnection: tosca.capabilities.Endpoint.Database
+
+
+topology_template:
+  description: Web Server Sample with Script
+  node_templates:
+    tomcat_server:
+      type: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
+      properties:
+        wars.root: "http://search.maven.org/remotecontent?filepath=io/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.6.0/brooklyn-example-hello-world-sql-webapp-0.6.0.war"
+        http.port: "8080+"
+        java.sysprops:
+          key1: value1
+      requirements:
+        - dbConnection:
+            node: mysql_server
+            relationship: brooklyn.relationships.Configure
+            properties:
+              prop.collection: java.sysprops
+              prop.name: brooklyn.example.db.url
+              prop.value: $brooklyn:formatString("jdbc:%s%s?user=%s\\&password=%s", $brooklyn:component("mysql_server").attributeWhenReady("datastore.url"), "visitors", "brooklyn", "br00k11n")
+
+    mysql_server:
+      type: org.apache.brooklyn.entity.database.mysql.MySqlNode
+      properties:
+        datastore.creation.script.url: "https://raw.githubusercontent.com/apache/incubator-brooklyn/286448623c417f099a8bce1a4764d6aa4589c6ea/brooklyn-server/launcher/src/test/resources/visitors-creation-script.sql"
+
+  groups:
+    add_brooklyn_location:
+      members: [ mysql_server, tomcat_server ]
+      policies:
+      - brooklyn.location: localhost


### PR DESCRIPTION
When a relationship is configured the a `ConfigKey` value (maybe a `Flag`) is added to the EntitySpec`. However, this value addition does not take in account any old config value which might have configured previously. For example, 

```
   tomcat_server:
      type: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
      properties:
        java.sysprops:
          key1: value1
      requirements:
        - endpoint_configuration:
            node: backend
            relationship: brooklyn.relationships.Configure
            properties:
              prop.collection: java.sysprops
              prop.name: key2
              prop.value: value2
```

The generated `EntitySpec` has to contains two entries in  `java.sysprops` configuration field.
- `key1`: `value1``
- `key2`: `value2`

However, currently the generated entity just contains the `key2: value2` entry. 
Currently, `RelationshipModifier` adds a configuration to an spec invoking `ConfigKeyModifier.configureConfigKeysSpec` method,  which replace the previous values of any `EntitySpec`'s configuration. 
It looks that `ConfigKeyModifier.configureConfigKeysSpec` must be used for this task, because this method adds a configuration value to an entity spec, and if the entity spec already contains a  value for this configuration `ConfigKeyModifier.configureConfigKeysSpec` should replace the old value.
