### PR TITLE
In tests, enable tosca feature

### DIFF
--- a/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaTypePlanTransformer.java
+++ b/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaTypePlanTransformer.java
@@ -41,7 +41,7 @@ public class ToscaTypePlanTransformer extends AbstractTypePlanTransformer {
             .build();
 
     @VisibleForTesting
-    static final String FEATURE_TOSCA_ENABLED = BrooklynFeatureEnablement.FEATURE_PROPERTY_PREFIX + ".tosca";
+    public static final String FEATURE_TOSCA_ENABLED = BrooklynFeatureEnablement.FEATURE_PROPERTY_PREFIX + ".tosca";
     private static final AtomicBoolean hasLoggedDisabled = new AtomicBoolean(false);
 
     private static final ConfigKey<String> TOSCA_ID = ConfigKeys.newStringConfigKey("tosca.id");

--- a/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/Alien4CloudIntegrationTest.java
+++ b/brooklyn-tosca-transformer/src/test/java/io/cloudsoft/tosca/a4c/Alien4CloudIntegrationTest.java
@@ -7,6 +7,7 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.camp.brooklyn.BrooklynCampPlatformLauncherNoServer;
+import org.apache.brooklyn.core.BrooklynFeatureEnablement;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.typereg.RegisteredTypes;
@@ -34,8 +35,13 @@ public class Alien4CloudIntegrationTest extends AbstractTestNGSpringContextTests
     protected ToscaTypePlanTransformer transformer;
     protected Uploader uploader;
 
+    protected Boolean origFeatureEnablement;
+    
     @BeforeMethod(alwaysRun = true)
     public void setUp() throws Exception {
+    	origFeatureEnablement = BrooklynFeatureEnablement.isEnabled(ToscaTypePlanTransformer.FEATURE_TOSCA_ENABLED);
+    	BrooklynFeatureEnablement.setDefault(ToscaTypePlanTransformer.FEATURE_TOSCA_ENABLED, true);
+    	
         assertNotNull(super.applicationContext, "No application context for test");
         Alien4CloudToscaPlatform.grantAdminAuth();
         this.platform = super.applicationContext.getBean(Alien4CloudToscaPlatform.class);
@@ -62,6 +68,9 @@ public class Alien4CloudIntegrationTest extends AbstractTestNGSpringContextTests
             LOG.error("Caught exception in tearDown method", e);
         } finally {
             this.mgmt = null;
+        	if (origFeatureEnablement != null) {
+        		BrooklynFeatureEnablement.setDefault(ToscaTypePlanTransformer.FEATURE_TOSCA_ENABLED, origFeatureEnablement);
+        	}
         }
     }
 


### PR DESCRIPTION
I accidentally broke `ToscaTypePlanTransformerIntegrationTest` tests in https://github.com/cloudsoft/brooklyn-tosca/pull/107 by removing the default enablement.

This change ensures the default enablement is set to true for the duration of the test. But it just sets the default. If someone runs the tests with a system property that explicitly enables/disables, then that will take precedence.
