### PR TITLE
Fix deployment of TOSCA application on Karaf

### DIFF
--- a/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaEntitySpecResolver.java
+++ b/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaEntitySpecResolver.java
@@ -11,15 +11,23 @@ public class ToscaEntitySpecResolver extends AbstractEntitySpecResolver {
 
     private static final String RESOLVER_NAME = "alien4cloud_deployment_topology";
 
+    private ToscaTypePlanTransformer toscaTypePlanTransformer;
+
     public ToscaEntitySpecResolver() {
         super(RESOLVER_NAME);
     }
 
     @Override
     public EntitySpec<?> resolve(String type, BrooklynClassLoadingContext loader, Set<String> encounteredTypes) {
-        ToscaTypePlanTransformer transformer = new ToscaTypePlanTransformer();
-        transformer.setManagementContext(mgmt);
+        if (null == toscaTypePlanTransformer) {
+            toscaTypePlanTransformer = new ToscaTypePlanTransformer();
+        }
+        toscaTypePlanTransformer.setManagementContext(mgmt);
 
-        return transformer.createApplicationSpecFromTopologyId(getLocalType(type));
+        return toscaTypePlanTransformer.createApplicationSpecFromTopologyId(getLocalType(type));
+    }
+
+    public void setToscaTypePlanTransformer(ToscaTypePlanTransformer toscaTypePlanTransformer) {
+        this.toscaTypePlanTransformer = toscaTypePlanTransformer;
     }
 }

--- a/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaEntitySpecResolver.java
+++ b/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaEntitySpecResolver.java
@@ -27,6 +27,7 @@ public class ToscaEntitySpecResolver extends AbstractEntitySpecResolver {
         return toscaTypePlanTransformer.createApplicationSpecFromTopologyId(getLocalType(type));
     }
 
+    // Note this is used to inject the type plan transformer bean in the OSGI blueprint.xml context.
     public void setToscaTypePlanTransformer(ToscaTypePlanTransformer toscaTypePlanTransformer) {
         this.toscaTypePlanTransformer = toscaTypePlanTransformer;
     }

--- a/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/plan/ToscaTypePlanTransformer.java
+++ b/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/plan/ToscaTypePlanTransformer.java
@@ -84,14 +84,12 @@ public class ToscaTypePlanTransformer extends AbstractTypePlanTransformer {
 
     private void initialiseAlien() {
         try {
-            synchronized (ToscaTypePlanTransformer.class) {
-                platform = mgmt.getConfig().getConfig(TOSCA_ALIEN_PLATFORM);
-                if (platform == null) {
-                    Alien4CloudToscaPlatform.grantAdminAuth();
-                    if (platformFactory==null) platformFactory = new AlienPlatformFactory.Default();
-                    platform = platformFactory.newPlatform(mgmt);
-                    ((LocalManagementContext) mgmt).getBrooklynProperties().put(TOSCA_ALIEN_PLATFORM, platform);
-                }
+            platform = mgmt.getConfig().getConfig(TOSCA_ALIEN_PLATFORM);
+            if (platform == null) {
+                Alien4CloudToscaPlatform.grantAdminAuth();
+                if (platformFactory==null) platformFactory = new AlienPlatformFactory.Default();
+                platform = platformFactory.newPlatform(mgmt);
+                ((LocalManagementContext) mgmt).getBrooklynProperties().put(TOSCA_ALIEN_PLATFORM, platform);
             }
             alienInitialised.set(true);
         } catch (Exception e) {

--- a/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/plan/ToscaTypePlanTransformer.java
+++ b/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/plan/ToscaTypePlanTransformer.java
@@ -67,7 +67,7 @@ public class ToscaTypePlanTransformer extends AbstractTypePlanTransformer {
     }
 
     @Override
-    public void setManagementContext(ManagementContext managementContext) {
+    public synchronized void setManagementContext(ManagementContext managementContext) {
         if (!isEnabled()) {
             if (hasLoggedDisabled.compareAndSet(false, true)) {
                 log.info("Not loading brooklyn-tosca platform: feature disabled");

--- a/karaf/init/pom.xml
+++ b/karaf/init/pom.xml
@@ -15,11 +15,6 @@
     <dependencies>
         <dependency>
             <groupId>io.cloudsoft.brooklyn.tosca</groupId>
-            <artifactId>brooklyn-tosca-karaf-deps-brooklyn</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.cloudsoft.brooklyn.tosca</groupId>
             <artifactId>_brooklyn-tosca-karaf-patches</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -35,9 +30,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-<!--
-                <version>3.2.0</version>
--->
                 <extensions>true</extensions>
                 <configuration>
                     <supportedProjectTypes>
@@ -53,12 +45,6 @@
                     </supportedProjectTypes>
           <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-<!--
-            <Import-Package>org.apache.brooklyn.*</Import-Package>
--->
-<Require-Bundle>
-  brooklyn-tosca-karaf-deps-brooklyn
-</Require-Bundle>
                         <Embed-Transitive>true</Embed-Transitive>
                         <!-- see note in parent README, run command in brooklyn-deps to generate group id exclusions -->
                         <Embed-Dependency>
@@ -67,9 +53,7 @@
                         <Bundle-ClassPath>.,_brooklyn-tosca-karaf-patches-${project.version}.jar</Bundle-ClassPath>
             <Import-Package>org.apache.brooklyn.api.*</Import-Package>
             <DynamicImport-Package>*</DynamicImport-Package>
-<!--
-            <Export-Package>io.cloudsoft.tosca.a4c.brooklyn.osgi</Export-Package>
--->
+            <Export-Package>!*</Export-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/karaf/init/pom.xml
+++ b/karaf/init/pom.xml
@@ -52,6 +52,10 @@
                         </Embed-Dependency>
                         <Bundle-ClassPath>.,_brooklyn-tosca-karaf-patches-${project.version}.jar</Bundle-ClassPath>
             <Import-Package>org.apache.brooklyn.api.*</Import-Package>
+            <!--
+                Note: using DynamicImport-Package here to bring in packages as required. Worth mentioning that
+                another approach would be to use Require-Bundle, which can be seen in the git history for this file.
+            -->
             <DynamicImport-Package>*</DynamicImport-Package>
             <Export-Package>!*</Export-Package>
           </instructions>

--- a/karaf/init/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/osgi/AlienPlatformFactoryOsgi.java
+++ b/karaf/init/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/osgi/AlienPlatformFactoryOsgi.java
@@ -20,13 +20,16 @@ public class AlienPlatformFactoryOsgi implements AlienPlatformFactory {
         // TODO only do the above once, cache static
         
         ClassLoader oldCL = null;
-        oldCL = Thread.currentThread().getContextClassLoader(); 
-        Thread.currentThread().setContextClassLoader(rl.getClass().getClassLoader());
-        
-        ApplicationContext applicationContext = Alien4CloudSpringContext.newApplicationContext(mgmt, rl);
-        ToscaPlatform result = applicationContext.getBean(ToscaPlatform.class);
-        
-        Thread.currentThread().setContextClassLoader(oldCL);
+        ToscaPlatform result;
+        try {
+            oldCL = Thread.currentThread().getContextClassLoader();
+            Thread.currentThread().setContextClassLoader(rl.getClass().getClassLoader());
+
+            ApplicationContext applicationContext = Alien4CloudSpringContext.newApplicationContext(mgmt, rl);
+            result = applicationContext.getBean(ToscaPlatform.class);
+        } finally {
+            Thread.currentThread().setContextClassLoader(oldCL);
+        }
 
         return result;
     }

--- a/karaf/init/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/osgi/ToscaTypePlanTransformerClassloaderWrapper.java
+++ b/karaf/init/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/osgi/ToscaTypePlanTransformerClassloaderWrapper.java
@@ -19,6 +19,10 @@ import java.util.List;
  * using org.springframework.util.ClassUtils#getDefaultClassLoader() will find the
  * classloader for this bundle, rather than whatever may happen to be in place at the
  * point of call.
+ *
+ * Note that the subclassing of ToscaTypePlanTransformer is only required so that
+ * a bean of this type can be injected into the {@link io.cloudsoft.tosca.a4c.brooklyn.ToscaEntitySpecResolver},
+ * which needs the {@link #createApplicationSpecFromTopologyId}.
  */
 public class ToscaTypePlanTransformerClassloaderWrapper extends ToscaTypePlanTransformer implements BrooklynTypePlanTransformer {
 

--- a/karaf/init/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/osgi/ToscaTypePlanTransformerClassloaderWrapper.java
+++ b/karaf/init/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/osgi/ToscaTypePlanTransformerClassloaderWrapper.java
@@ -1,6 +1,9 @@
 package io.cloudsoft.tosca.a4c.brooklyn.osgi;
 
 import io.cloudsoft.tosca.a4c.brooklyn.plan.ToscaTypePlanTransformer;
+import org.apache.brooklyn.api.entity.Application;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.internal.AbstractBrooklynObjectSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.api.typereg.RegisteredTypeLoadingContext;
@@ -17,7 +20,7 @@ import java.util.List;
  * classloader for this bundle, rather than whatever may happen to be in place at the
  * point of call.
  */
-public class ToscaTypePlanTransformerClassloaderWrapper implements BrooklynTypePlanTransformer {
+public class ToscaTypePlanTransformerClassloaderWrapper extends ToscaTypePlanTransformer implements BrooklynTypePlanTransformer {
 
     ToscaTypePlanTransformer delegateTransformer;
 
@@ -115,6 +118,27 @@ public class ToscaTypePlanTransformerClassloaderWrapper implements BrooklynTypeP
         try {
             Thread.currentThread().setContextClassLoader(toscaClassLoader());
             delegateTransformer.setManagementContext(managementContext);
+        } finally {
+            Thread.currentThread().setContextClassLoader(original);
+        }
+    }
+
+    @Override
+    public EntitySpec<? extends Application> createApplicationSpecFromTopologyId(String id) {
+        final ClassLoader original = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(toscaClassLoader());
+            return delegateTransformer.createApplicationSpecFromTopologyId(id);
+        } finally {
+            Thread.currentThread().setContextClassLoader(original);
+        }
+    }
+
+    public AbstractBrooklynObjectSpec<?, ?> createSpec(RegisteredType type, RegisteredTypeLoadingContext context) throws Exception {
+        final ClassLoader original = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(toscaClassLoader());
+            return delegateTransformer.createSpec(type, context);
         } finally {
             Thread.currentThread().setContextClassLoader(original);
         }

--- a/karaf/init/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/karaf/init/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -6,7 +6,7 @@
     <bean id="toscaPlatformFactory"
           class="io.cloudsoft.tosca.a4c.brooklyn.osgi.AlienPlatformFactoryOsgi"/>
 
-    <bean id="toscaTypePlanTransformer" scope="prototype"
+    <bean id="toscaTypePlanTransformer"
           class="io.cloudsoft.tosca.a4c.brooklyn.plan.ToscaTypePlanTransformer" >
         <property name="platformFactory" ref="toscaPlatformFactory"/>
     </bean>
@@ -18,5 +18,13 @@
 
     <service ref="toscaTypePlanTransformerOsgi"
              interface="org.apache.brooklyn.core.typereg.BrooklynTypePlanTransformer" />
+
+    <bean id="toscaEntitySpecResolver"
+          class="io.cloudsoft.tosca.a4c.brooklyn.ToscaEntitySpecResolver" >
+        <property name="toscaTypePlanTransformer" ref="toscaTypePlanTransformerOsgi" />
+    </bean>
+
+    <service ref="toscaEntitySpecResolver"
+             interface="org.apache.brooklyn.core.resolve.entity.EntitySpecResolver" />
 
 </blueprint>


### PR DESCRIPTION
Merge this after https://github.com/cloudsoft/brooklyn-tosca/pull/116.

The main requirement here was to expose the ToscaEntitySpecResolver bean:
- added a bean to blueprint.xml for the ToscaEntitySpecResover
- added ability to inject the ToscaTypePlanTransformer used within the resolver
  and used this in the blueprint.xml
- made the classloader wrapper extend ToscaTypePlanTransformer so it can be
  injected into the resolver bean
- added the additional public methods to the classloader wrapper that are
  brought into it by extending ToscaTypePlanTransformer

This allowed me to successfully deploy the example application following the instructions on the AMP docs.
