### PR TITLE
brooklyn-tosca tidy-ups

### DIFF
--- a/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaEntitySpecResolver.java
+++ b/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaEntitySpecResolver.java
@@ -11,15 +11,23 @@ public class ToscaEntitySpecResolver extends AbstractEntitySpecResolver {
 
     private static final String RESOLVER_NAME = "alien4cloud_deployment_topology";
 
+    private ToscaTypePlanTransformer toscaTypePlanTransformer;
+
     public ToscaEntitySpecResolver() {
         super(RESOLVER_NAME);
     }
 
     @Override
     public EntitySpec<?> resolve(String type, BrooklynClassLoadingContext loader, Set<String> encounteredTypes) {
-        ToscaTypePlanTransformer transformer = new ToscaTypePlanTransformer();
-        transformer.setManagementContext(mgmt);
+        if (null == toscaTypePlanTransformer) {
+            toscaTypePlanTransformer = new ToscaTypePlanTransformer();
+        }
+        toscaTypePlanTransformer.setManagementContext(mgmt);
 
-        return transformer.createApplicationSpecFromTopologyId(getLocalType(type));
+        return toscaTypePlanTransformer.createApplicationSpecFromTopologyId(getLocalType(type));
+    }
+
+    public void setToscaTypePlanTransformer(ToscaTypePlanTransformer toscaTypePlanTransformer) {
+        this.toscaTypePlanTransformer = toscaTypePlanTransformer;
     }
 }

--- a/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaEntitySpecResolver.java
+++ b/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/ToscaEntitySpecResolver.java
@@ -27,6 +27,7 @@ public class ToscaEntitySpecResolver extends AbstractEntitySpecResolver {
         return toscaTypePlanTransformer.createApplicationSpecFromTopologyId(getLocalType(type));
     }
 
+    // Note this is used to inject the type plan transformer bean in the OSGI blueprint.xml context.
     public void setToscaTypePlanTransformer(ToscaTypePlanTransformer toscaTypePlanTransformer) {
         this.toscaTypePlanTransformer = toscaTypePlanTransformer;
     }

--- a/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/plan/ToscaTypePlanTransformer.java
+++ b/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/plan/ToscaTypePlanTransformer.java
@@ -84,14 +84,12 @@ public class ToscaTypePlanTransformer extends AbstractTypePlanTransformer {
 
     private void initialiseAlien() {
         try {
-            synchronized (ToscaTypePlanTransformer.class) {
-                platform = mgmt.getConfig().getConfig(TOSCA_ALIEN_PLATFORM);
-                if (platform == null) {
-                    Alien4CloudToscaPlatform.grantAdminAuth();
-                    if (platformFactory==null) platformFactory = new AlienPlatformFactory.Default();
-                    platform = platformFactory.newPlatform(mgmt);
-                    ((LocalManagementContext) mgmt).getBrooklynProperties().put(TOSCA_ALIEN_PLATFORM, platform);
-                }
+            platform = mgmt.getConfig().getConfig(TOSCA_ALIEN_PLATFORM);
+            if (platform == null) {
+                Alien4CloudToscaPlatform.grantAdminAuth();
+                if (platformFactory==null) platformFactory = new AlienPlatformFactory.Default();
+                platform = platformFactory.newPlatform(mgmt);
+                ((LocalManagementContext) mgmt).getBrooklynProperties().put(TOSCA_ALIEN_PLATFORM, platform);
             }
             alienInitialised.set(true);
         } catch (Exception e) {

--- a/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/plan/ToscaTypePlanTransformer.java
+++ b/brooklyn-tosca-transformer/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/plan/ToscaTypePlanTransformer.java
@@ -67,7 +67,7 @@ public class ToscaTypePlanTransformer extends AbstractTypePlanTransformer {
     }
 
     @Override
-    public void setManagementContext(ManagementContext managementContext) {
+    public synchronized void setManagementContext(ManagementContext managementContext) {
         if (!isEnabled()) {
             if (hasLoggedDisabled.compareAndSet(false, true)) {
                 log.info("Not loading brooklyn-tosca platform: feature disabled");

--- a/karaf/README.md
+++ b/karaf/README.md
@@ -1,29 +1,4 @@
 
-TO run:
-
-1) add these to etc/brooklyn.cfg in the karaf/cloudsoft-amp target assembly (adjusting paths as needed):
-
-brooklyn.experimental.feature.tosca=true
-alien4cloud-config.file=/Users/alex/dev/gits/brooklyn-tosca/brooklyn-tosca-dist/src/main/assembly/files/conf/alien4cloud-config.yml
-
-
-2) whenever karaf is built
-
-feature:repo-add mvn:io.cloudsoft.brooklyn.tosca/brooklyn-tosca-karaf-features/0.10.0-SNAPSHOT/xml/features
-feature:install brooklyn-tosca-karaf-features
-
-
-the feature installation will probably fail; so far, some things have been fixed with:
-
-bundle:install 'wrap:mvn:com.jcraft/jsch/0.1.50$Bundle-SymbolicName=com.jcraft.jsch&Bundle-Version=0.1.50'
-bundle:install 'wrap:mvn:org.springframework/spring-beans/3.2.8.RELEASE$Bundle-SymbolicName=org.springframework.beans&Bundle-Version=3.2.8.RELEASE&Export-Package=*;version=3.2.8.RELEASE'
-bundle:install 'wrap:mvn:org.springframework/spring-context/3.2.8.RELEASE$Bundle-SymbolicName=org.springframework.context&Bundle-Version=3.2.8.RELEASE&Export-Package=*;version=3.2.8.RELEASE'
-
-but this is not a promising path as we're only on 'c', and core is next,
-and also we have a diff version of core already included
-
-
-
 FOR reference:
 
 the DEPENDENCIES.txt in this folder gives a tree of the actual dependencies pulled in.

--- a/karaf/features/pom.xml
+++ b/karaf/features/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.cloudsoft.brooklyn.tosca</groupId>
         <artifactId>brooklyn-tosca-karaf</artifactId>
-        <version>0.10.0-SNAPSHOT</version> <!-- BROOKLYN_TOSCA_VERSION -->
+        <version>0.10.0-SNAPSHOT</version>  <!-- BROOKLYN_TOSCA_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -33,14 +33,6 @@
 
     <name>Brooklyn Tosca Karaf Features</name>
     <packaging>feature</packaging>
-
-    <dependencies>
-        <dependency>
-            <groupId>io.cloudsoft.brooklyn.tosca</groupId>
-            <artifactId>brooklyn-tosca-karaf-init</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-    </dependencies>
 
     <build>
         <plugins>

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.4.0" name="${project.groupId}-${project.version}">
+
+    <feature name="brooklyn-tosca" version="${project.version}">
+        <bundle>mvn:io.cloudsoft.brooklyn.tosca/brooklyn-tosca-karaf-init/${project.version}</bundle>
+        <bundle dependency="true">mvn:org.apache.brooklyn/brooklyn-launcher-common/${brooklyn.version}</bundle>
+    </feature>
+
+</features>

--- a/karaf/init/pom.xml
+++ b/karaf/init/pom.xml
@@ -15,11 +15,6 @@
     <dependencies>
         <dependency>
             <groupId>io.cloudsoft.brooklyn.tosca</groupId>
-            <artifactId>brooklyn-tosca-karaf-deps-brooklyn</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.cloudsoft.brooklyn.tosca</groupId>
             <artifactId>_brooklyn-tosca-karaf-patches</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -35,9 +30,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-<!--
-                <version>3.2.0</version>
--->
                 <extensions>true</extensions>
                 <configuration>
                     <supportedProjectTypes>
@@ -53,12 +45,6 @@
                     </supportedProjectTypes>
           <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-<!--
-            <Import-Package>org.apache.brooklyn.*</Import-Package>
--->
-<Require-Bundle>
-  brooklyn-tosca-karaf-deps-brooklyn
-</Require-Bundle>
                         <Embed-Transitive>true</Embed-Transitive>
                         <!-- see note in parent README, run command in brooklyn-deps to generate group id exclusions -->
                         <Embed-Dependency>
@@ -67,9 +53,7 @@
                         <Bundle-ClassPath>.,_brooklyn-tosca-karaf-patches-${project.version}.jar</Bundle-ClassPath>
             <Import-Package>org.apache.brooklyn.api.*</Import-Package>
             <DynamicImport-Package>*</DynamicImport-Package>
-<!--
-            <Export-Package>io.cloudsoft.tosca.a4c.brooklyn.osgi</Export-Package>
--->
+            <Export-Package>!*</Export-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/karaf/init/pom.xml
+++ b/karaf/init/pom.xml
@@ -15,7 +15,7 @@
     <dependencies>
         <dependency>
             <groupId>io.cloudsoft.brooklyn.tosca</groupId>
-            <artifactId>_brooklyn-tosca-karaf-patches</artifactId>
+            <artifactId>brooklyn-tosca-karaf-patches</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -50,7 +50,7 @@
                         <Embed-Dependency>
                             *;groupId=!aopalliance|asm|ch.qos.logback|com.fasterxml.jackson.core|com.fasterxml.jackson.jaxrs|com.fasterxml.jackson.module|com.google.code.findbugs|com.google.code.gson|com.google.guava|com.google.http-client|com.google.inject|com.google.inject.extensions|com.jamesmurty.utils|com.jayway.jsonpath|com.jcraft|com.maxmind.db|com.maxmind.geoip2|com.squareup.okhttp|com.squareup.okio|com.sun.xml.bind|com.thoughtworks.xstream|commons-beanutils|commons-codec|commons-io|commons-logging|dom4j|io.cloudsoft.windows|javax.annotation|javax.inject|net.iharder|net.java.dev.jna|net.minidev|net.schmizz|org.99soft.guice|org.apache.brooklyn|org.apache.brooklyn.camp|org.apache.cxf|org.apache.felix|org.apache.httpcomponents|org.apache.jclouds|org.apache.jclouds.api|org.apache.jclouds.common|org.apache.jclouds.driver|org.apache.jclouds.labs|org.apache.jclouds.provider|org.apache.neethi|org.apache.ws.xmlschema|org.bouncycastle|org.codehaus.groovy|org.freemarker|org.glassfish.external|org.javassist|org.osgi|org.ow2.asm|org.reflections|org.slf4j|org.tukaani|org.yaml|wsdl4j|xml-resolver|xmlpull|xpp3
                         </Embed-Dependency>
-                        <Bundle-ClassPath>.,_brooklyn-tosca-karaf-patches-${project.version}.jar</Bundle-ClassPath>
+                        <Bundle-ClassPath>.,brooklyn-tosca-karaf-patches-${project.version}.jar</Bundle-ClassPath>
             <Import-Package>org.apache.brooklyn.api.*</Import-Package>
             <DynamicImport-Package>*</DynamicImport-Package>
             <Export-Package>!*</Export-Package>

--- a/karaf/init/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/osgi/AlienPlatformFactoryOsgi.java
+++ b/karaf/init/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/osgi/AlienPlatformFactoryOsgi.java
@@ -20,13 +20,16 @@ public class AlienPlatformFactoryOsgi implements AlienPlatformFactory {
         // TODO only do the above once, cache static
         
         ClassLoader oldCL = null;
-        oldCL = Thread.currentThread().getContextClassLoader(); 
-        Thread.currentThread().setContextClassLoader(rl.getClass().getClassLoader());
-        
-        ApplicationContext applicationContext = Alien4CloudSpringContext.newApplicationContext(mgmt, rl);
-        ToscaPlatform result = applicationContext.getBean(ToscaPlatform.class);
-        
-        Thread.currentThread().setContextClassLoader(oldCL);
+        ToscaPlatform result;
+        try {
+            oldCL = Thread.currentThread().getContextClassLoader();
+            Thread.currentThread().setContextClassLoader(rl.getClass().getClassLoader());
+
+            ApplicationContext applicationContext = Alien4CloudSpringContext.newApplicationContext(mgmt, rl);
+            result = applicationContext.getBean(ToscaPlatform.class);
+        } finally {
+            Thread.currentThread().setContextClassLoader(oldCL);
+        }
 
         return result;
     }

--- a/karaf/init/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/osgi/ToscaTypePlanTransformerClassloaderWrapper.java
+++ b/karaf/init/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/osgi/ToscaTypePlanTransformerClassloaderWrapper.java
@@ -19,6 +19,10 @@ import java.util.List;
  * using org.springframework.util.ClassUtils#getDefaultClassLoader() will find the
  * classloader for this bundle, rather than whatever may happen to be in place at the
  * point of call.
+ *
+ * Note that the subclassing of ToscaTypePlanTransformer is only required so that
+ * a bean of this type can be injected into the {@link io.cloudsoft.tosca.a4c.brooklyn.ToscaEntitySpecResolver},
+ * which needs the {@link #createApplicationSpecFromTopologyId}.
  */
 public class ToscaTypePlanTransformerClassloaderWrapper extends ToscaTypePlanTransformer implements BrooklynTypePlanTransformer {
 

--- a/karaf/init/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/osgi/ToscaTypePlanTransformerClassloaderWrapper.java
+++ b/karaf/init/src/main/java/io/cloudsoft/tosca/a4c/brooklyn/osgi/ToscaTypePlanTransformerClassloaderWrapper.java
@@ -1,6 +1,9 @@
 package io.cloudsoft.tosca.a4c.brooklyn.osgi;
 
 import io.cloudsoft.tosca.a4c.brooklyn.plan.ToscaTypePlanTransformer;
+import org.apache.brooklyn.api.entity.Application;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.internal.AbstractBrooklynObjectSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.api.typereg.RegisteredTypeLoadingContext;
@@ -17,7 +20,7 @@ import java.util.List;
  * classloader for this bundle, rather than whatever may happen to be in place at the
  * point of call.
  */
-public class ToscaTypePlanTransformerClassloaderWrapper implements BrooklynTypePlanTransformer {
+public class ToscaTypePlanTransformerClassloaderWrapper extends ToscaTypePlanTransformer implements BrooklynTypePlanTransformer {
 
     ToscaTypePlanTransformer delegateTransformer;
 
@@ -115,6 +118,27 @@ public class ToscaTypePlanTransformerClassloaderWrapper implements BrooklynTypeP
         try {
             Thread.currentThread().setContextClassLoader(toscaClassLoader());
             delegateTransformer.setManagementContext(managementContext);
+        } finally {
+            Thread.currentThread().setContextClassLoader(original);
+        }
+    }
+
+    @Override
+    public EntitySpec<? extends Application> createApplicationSpecFromTopologyId(String id) {
+        final ClassLoader original = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(toscaClassLoader());
+            return delegateTransformer.createApplicationSpecFromTopologyId(id);
+        } finally {
+            Thread.currentThread().setContextClassLoader(original);
+        }
+    }
+
+    public AbstractBrooklynObjectSpec<?, ?> createSpec(RegisteredType type, RegisteredTypeLoadingContext context) throws Exception {
+        final ClassLoader original = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(toscaClassLoader());
+            return delegateTransformer.createSpec(type, context);
         } finally {
             Thread.currentThread().setContextClassLoader(original);
         }

--- a/karaf/init/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/karaf/init/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -6,7 +6,7 @@
     <bean id="toscaPlatformFactory"
           class="io.cloudsoft.tosca.a4c.brooklyn.osgi.AlienPlatformFactoryOsgi"/>
 
-    <bean id="toscaTypePlanTransformer" scope="prototype"
+    <bean id="toscaTypePlanTransformer"
           class="io.cloudsoft.tosca.a4c.brooklyn.plan.ToscaTypePlanTransformer" >
         <property name="platformFactory" ref="toscaPlatformFactory"/>
     </bean>
@@ -18,5 +18,13 @@
 
     <service ref="toscaTypePlanTransformerOsgi"
              interface="org.apache.brooklyn.core.typereg.BrooklynTypePlanTransformer" />
+
+    <bean id="toscaEntitySpecResolver"
+          class="io.cloudsoft.tosca.a4c.brooklyn.ToscaEntitySpecResolver" >
+        <property name="toscaTypePlanTransformer" ref="toscaTypePlanTransformerOsgi" />
+    </bean>
+
+    <service ref="toscaEntitySpecResolver"
+             interface="org.apache.brooklyn.core.resolve.entity.EntitySpecResolver" />
 
 </blueprint>

--- a/karaf/patches/pom.xml
+++ b/karaf/patches/pom.xml
@@ -8,8 +8,8 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>_brooklyn-tosca-karaf-patches</artifactId>
-    <name>Brooklyn TOSCA Karaf Patched Jars (_ to place first on classpath)</name>
+    <artifactId>brooklyn-tosca-karaf-patches</artifactId>
+    <name>Brooklyn TOSCA Karaf Patched Jars</name>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Merge this after #117 .

Add a `brooklyn-tosca` feature to the feature project.
Removes an unnecessary underscore from the patches jar name.
