### PR TITLE
Change version to 0.11.0-SNAPSHOT

### DIFF
--- a/a4c-brooklyn-plugin/pom.xml
+++ b/a4c-brooklyn-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cloudsoft.brooklyn.tosca</groupId>
         <artifactId>brooklyn-tosca-parent</artifactId>
-        <version>0.10.0-SNAPSHOT</version> <!-- BROOKLYN_TOSCA_VERSION -->
+        <version>0.11.0-SNAPSHOT</version> <!-- BROOKLYN_TOSCA_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/brooklyn-tosca-common/pom.xml
+++ b/brooklyn-tosca-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cloudsoft.brooklyn.tosca</groupId>
         <artifactId>brooklyn-tosca-parent</artifactId>
-        <version>0.10.0-SNAPSHOT</version> <!-- BROOKLYN_TOSCA_VERSION -->
+        <version>0.11.0-SNAPSHOT</version> <!-- BROOKLYN_TOSCA_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/brooklyn-tosca-dist/pom.xml
+++ b/brooklyn-tosca-dist/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.cloudsoft.brooklyn.tosca</groupId>
         <artifactId>brooklyn-tosca-parent</artifactId>
-        <version>0.10.0-SNAPSHOT</version> <!-- BROOKLYN_TOSCA_VERSION -->
+        <version>0.11.0-SNAPSHOT</version> <!-- BROOKLYN_TOSCA_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/brooklyn-tosca-transformer/pom.xml
+++ b/brooklyn-tosca-transformer/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.cloudsoft.brooklyn.tosca</groupId>
         <artifactId>brooklyn-tosca-parent</artifactId>
-        <version>0.10.0-SNAPSHOT</version> <!-- BROOKLYN_TOSCA_VERSION -->
+        <version>0.11.0-SNAPSHOT</version> <!-- BROOKLYN_TOSCA_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/karaf/deps-brooklyn/pom.xml
+++ b/karaf/deps-brooklyn/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cloudsoft.brooklyn.tosca</groupId>
         <artifactId>brooklyn-tosca-karaf</artifactId>
-        <version>0.10.0-SNAPSHOT</version> <!-- BROOKLYN_TOSCA_VERSION -->
+        <version>0.11.0-SNAPSHOT</version> <!-- BROOKLYN_TOSCA_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/karaf/features/pom.xml
+++ b/karaf/features/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.cloudsoft.brooklyn.tosca</groupId>
         <artifactId>brooklyn-tosca-karaf</artifactId>
-        <version>0.10.0-SNAPSHOT</version>  <!-- BROOKLYN_TOSCA_VERSION -->
+        <version>0.11.0-SNAPSHOT</version>  <!-- BROOKLYN_TOSCA_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/karaf/init/pom.xml
+++ b/karaf/init/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cloudsoft.brooklyn.tosca</groupId>
         <artifactId>brooklyn-tosca-karaf</artifactId>
-        <version>0.10.0-SNAPSHOT</version> <!-- BROOKLYN_TOSCA_VERSION -->
+        <version>0.11.0-SNAPSHOT</version> <!-- BROOKLYN_TOSCA_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/karaf/patches/pom.xml
+++ b/karaf/patches/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cloudsoft.brooklyn.tosca</groupId>
         <artifactId>brooklyn-tosca-karaf</artifactId>
-        <version>0.10.0-SNAPSHOT</version> <!-- BROOKLYN_TOSCA_VERSION -->
+        <version>0.11.0-SNAPSHOT</version> <!-- BROOKLYN_TOSCA_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cloudsoft.brooklyn.tosca</groupId>
     <artifactId>brooklyn-tosca-parent</artifactId>
-    <version>0.10.0-SNAPSHOT</version> <!-- BROOKLYN_TOSCA_VERSION -->
+    <version>0.11.0-SNAPSHOT</version> <!-- BROOKLYN_TOSCA_VERSION -->
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <groupId>io.cloudsoft.brooklyn.tosca</groupId>
     <artifactId>brooklyn-tosca-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.10.0-SNAPSHOT</version>  <!-- BROOKLYN_TOSCA_VERSION -->
+    <version>0.11.0-SNAPSHOT</version>  <!-- BROOKLYN_TOSCA_VERSION -->
 
     <name>Brooklyn TOSCA parent project</name>
 

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.cloudsoft.brooklyn.tosca</groupId>
         <artifactId>brooklyn-tosca-parent</artifactId>
-        <version>0.10.0-SNAPSHOT</version> <!-- BROOKLYN_TOSCA_VERSION -->
+        <version>0.11.0-SNAPSHOT</version> <!-- BROOKLYN_TOSCA_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Now that we've switched master to brooklyn 0.11.0-SNAPSHOT, we also need to bump the brooklyn-tosca version number.

I've also create a 0.10.x branch, which depends on 0.10.0-SNAPSHOT brooklyn (we'll release 0.10.0 once brooklyn 0.10.0 is released).