### PR TITLE
QA tests run Brooklyn with TOSCA enabled

### DIFF
--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -108,7 +108,7 @@
                     <plugin>
                         <groupId>io.brooklyn.maven</groupId>
                         <artifactId>brooklyn-maven-plugin</artifactId>
-                        <version>0.3.0-SNAPSHOT</version>
+                        <version>0.3.0</version>
                         <executions>
                             <execution>
                                 <id>Run Brooklyn</id>
@@ -118,6 +118,9 @@
                                 </goals>
                                 <configuration>
                                     <mainClass>io.cloudsoft.tosca.a4c.brooklyn.cli.BrooklynToscaMain</mainClass>
+                                    <javaOptions>
+                                        <javaOption>-Dbrooklyn.experimental.feature.tosca=true</javaOption>
+                                    </javaOptions>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
Now the tests fail because they expect Ubuntu and Brooklyn provisions CentOS.