### PR TITLE
Upgraded to brooklyn-1.1.0-SNAPSHOT and locked submodule alien4cloud to …

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "alien4cloud"]
 	path = alien4cloud
 	url = ../alien4cloud.git
+	commit = add5ed5a

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <alien.custom.version>1.1.0-SM8.cloudsoft</alien.custom.version>
         <spring.version>4.1.4.RELEASE</spring.version>
         <mockito-core.version>2.7.12</mockito-core.version>
-        <brooklyn.version>1.0.0</brooklyn.version>  <!-- BROOKLYN_VERSION -->
+        <brooklyn.version>1.1.0-SNAPSHOT</brooklyn.version>  <!-- BROOKLYN_VERSION -->
     </properties>
 
     <scm>


### PR DESCRIPTION
# What
Upgraded to `brooklyn-1.1.0-SNAPSHOT` and locked submodule `alien4cloud` to the last commit to prevent future incompatibilities and failures. 
# Why
When part of the megan project as a submodule it introduced dependency clashes because it depended on the old brooklyn version. 
# Notes
The locking of the alien4cloud submodule to a specific commit will prevent problems if the module will be updated separately and developed to become incompatible with Megan.